### PR TITLE
Make Prime and "Standard" model designations sort first

### DIFF
--- a/src/app/services/unit-search-filters.service.ts
+++ b/src/app/services/unit-search-filters.service.ts
@@ -691,7 +691,7 @@ export class UnitSearchFiltersService {
             if (sortKey === 'name') {
                 comparison = naturalCompare(a.chassis || '', b.chassis || '');
                 if (comparison === 0) {
-                    comparison = naturalCompare(a.model || '', b.model || '', /*is_model=*/true);
+                    comparison = naturalCompare(a.model || '', b.model || '', true);
                     if (comparison === 0) {
                         comparison = (a.year || 0) - (b.year || 0);
                     }

--- a/src/app/utils/sort.util.ts
+++ b/src/app/utils/sort.util.ts
@@ -39,7 +39,7 @@ type CacheEntry = { parts: Part[] };
 
 let naturalCompareCache = new Map<string, CacheEntry>();
 
-function tokenizeForNaturalCompare(s: string, is_model: boolean): CacheEntry {
+function tokenizeForNaturalCompare(s: string, isModel: boolean): CacheEntry {
     // Normalize input
     if (typeof s !== 'string') {
         if (s == null) s = '';
@@ -48,7 +48,7 @@ function tokenizeForNaturalCompare(s: string, is_model: boolean): CacheEntry {
     s = s.trim();
 
     // Make 'Prime' and 'Standard' variants go first, but only if this is the entire model name
-    if (is_model) {
+    if (isModel) {
         if (s == 'Prime') {
             const part: Part = {
                 raw: s,
@@ -84,12 +84,12 @@ function tokenizeForNaturalCompare(s: string, is_model: boolean): CacheEntry {
     return { parts };
 }
 
-function getCachedParts(s: string, is_model: boolean): CacheEntry {
+function getCachedParts(s: string, isModel: boolean): CacheEntry {
     const token = (typeof s === 'string') ? s : (s == null ? '' : String(s));
-    const key = token + is_model;
+    const key = token + (isModel ? '~model' : '');
     const existing = naturalCompareCache.get(key);
     if (existing) return existing;
-    const entry = tokenizeForNaturalCompare(token, is_model);
+    const entry = tokenizeForNaturalCompare(token, isModel);
     naturalCompareCache.set(key, entry);
     return entry;
 }
@@ -100,11 +100,11 @@ function getCachedParts(s: string, is_model: boolean): CacheEntry {
  * @param b The second string to compare.
  * @returns A negative number if a < b, a positive number if a > b, and 0 if they are equal.
  */
-export function naturalCompare(a: string, b: string, is_model: boolean = false): number {
+export function naturalCompare(a: string, b: string, isModel: boolean = false): number {
     if (a === b) return 0;
 
-    const entryA = getCachedParts(a, is_model);
-    const entryB = getCachedParts(b, is_model);
+    const entryA = getCachedParts(a, isModel);
+    const entryB = getCachedParts(b, isModel);
 
     const partsA = entryA.parts;
     const partsB = entryB.parts;


### PR DESCRIPTION
Treat "Prime" variants of clan omnimechs as lexically equivalent to "0" so that they go before "A" instead of next to "P". Similarly, treat no-designation "standard" clan mechs as numerically 0 so that they sort before 2. Pipe through extra state so that these transformations are only applied when using the `.model` comparison for units that already matched on `.chassis` when constructing `filteredUnits`.

Example screenshots with my change:
<img width="565" height="376" alt="Screenshot 2025-11-21 at 10 00 06 PM" src="https://github.com/user-attachments/assets/45a3cf05-2fd4-48fc-9772-8b6204d90848" />
<img width="590" height="553" alt="Screenshot 2025-11-21 at 10 00 16 PM" src="https://github.com/user-attachments/assets/44538cb3-d932-434e-802e-812a13ea0cbb" />
