### PR TITLE
Treat null tokens in mech strings as numerically zero

### DIFF
--- a/src/app/utils/sort.util.ts
+++ b/src/app/utils/sort.util.ts
@@ -47,22 +47,13 @@ function tokenizeForNaturalCompare(s: string, isModel: boolean): CacheEntry {
     }
     s = s.trim();
 
-    // Make 'Prime' and 'Standard' variants go first, but only if this is the entire model name
+    // Make 'Prime' variants go first, but only if this is the entire model name
     if (isModel) {
         if (s == 'Prime') {
             const part: Part = {
                 raw: s,
                 normalized: '0',
                 isNum: false,
-                num: 0
-            };
-            return {parts: [part]};
-        }
-        if (s == '') {
-            const part: Part = {
-                raw: s,
-                normalized: '0',
-                isNum: true,
                 num: 0
             };
             return {parts: [part]};
@@ -111,8 +102,8 @@ export function naturalCompare(a: string, b: string, isModel: boolean = false): 
 
     const maxLen = Math.max(partsA.length, partsB.length);
     for (let i = 0; i < maxLen; i++) {
-        const pa = partsA[i] || { raw: '', normalized: '', isNum: false };
-        const pb = partsB[i] || { raw: '', normalized: '', isNum: false };
+        const pa = partsA[i] || { raw: '', normalized: '', isNum: true, num: 0};
+        const pb = partsB[i] || { raw: '', normalized: '', isNum: true, num: 0};
 
         const isNumA = pa.isNum;
         const isNumB = pb.isNum;


### PR DESCRIPTION
This removes the special case for "standard" clan mechs, as that was doing the same thing in a sepcific place; this handles a more general case. With this change the preference for putting numbers first means that if two strings share a common prefix, the one with fewer tokens will always be sorted first.

For example, this causes "Rifleman C" to sort before "Rifleman C 2". This breaks the model strings down to ["C", 0, 0] vs ["C", "", 2]; the preference for numbers before strings means the comparison terminates at the second token, putting the 0 before "". Previously the two would compare equal for the middle token because " " is normalized to "", making it equal to the empty string extensions added into the shorter token list.