### PR TITLE
Restore sorting fix for "standard" variant clan mechs

### DIFF
--- a/src/app/utils/sort.util.ts
+++ b/src/app/utils/sort.util.ts
@@ -47,13 +47,22 @@ function tokenizeForNaturalCompare(s: string, isModel: boolean): CacheEntry {
     }
     s = s.trim();
 
-    // Make 'Prime' variants go first, but only if this is the entire model name
+    // Make 'Prime' and 'Standard' variants go first, but only if this is the entire model name
     if (isModel) {
         if (s == 'Prime') {
             const part: Part = {
                 raw: s,
                 normalized: '0',
                 isNum: false,
+                num: 0
+            };
+            return {parts: [part]};
+        }
+        if (s == '') {
+            const part: Part = {
+                raw: s,
+                normalized: '0',
+                isNum: true,
                 num: 0
             };
             return {parts: [part]};


### PR DESCRIPTION
Partially reverts b19db15bb7739938b8b2e5a953a4cbb825ae34af

The fix for multi-token models was good (sorting "Rifleman C" before "Rifleman C 2"), but the explicit case for model strings that were entirely blank ("Supernova" vs "Supernova 2") should have been left in.

Manually verified all known sort cases:
 * "Nova" (Prime goes first)
 * "Supernova" (Standard goes first)
 * "Atlas K" (AS7-K goes before AS7-K2)
 * "Rifleman C" (Rifleman C goes before Rifleman C 2)