### PR TITLE
fix: Force Pack - Third Star League Strike Team 

### DIFF
--- a/src/app/models/forcepacks.model.ts
+++ b/src/app/models/forcepacks.model.ts
@@ -1285,7 +1285,7 @@ const FORCE_PACKS: ForcePack[] = [
         "name": "BMKintaro_KTO20"
       },
       {
-        "name": "BMKraken_3"
+        "name": "BMHammerhead"
       },
       {
         "name": "BMHavoc_HVCP6"


### PR DESCRIPTION
I apologize in advance if I am not following some established PR practices.

### Problem
The force pack definition incorrectly included Kraken (Bane) instead of Hammerhead.

### Changes
**Modified**: `src/app/models/forcepacks.model.ts`

- Removed: `BMKraken_3`
- Added: `BMHammerhead`

### Correct Composition
1. Lament
2. Jackalope
3. Kintaro
4. Hammerhead (corrected)
5. Havoc
6. J-27 Ordnance Transport

### Verification
- Unit `BMHammerhead` exists in units database
- Composition matches official Sarna wiki documentation

### References
- [BattleTech: Third Star League Strike Team - Sarna](https://www.sarna.net/wiki/BattleTech:_Third_Star_League_Strike_Team)
