### PR TITLE
feat: Add sorting to headers in table

### DIFF
--- a/src/app/components/unit-search/unit-search.component.html
+++ b/src/app/components/unit-search/unit-search.component.html
@@ -141,17 +141,61 @@
             @if (this.expandedView() && gameService.isAlphaStrike() && viewMode() === 'list') {
             <div class="as-table-header">
                 <div class="as-th as-th-icon"></div>
-                <div class="as-th as-th-name">Name</div>
-                <div class="as-th as-th-type">Type</div>
-                <div class="as-th as-th-role">Role</div>
-                <div class="as-th as-th-pv">PV</div>
-                <div class="as-th as-th-sz">SZ</div>
-                <div class="as-th as-th-mv">MV</div>
-                <div class="as-th as-th-tmm">TMM</div>
-                <div class="as-th as-th-dmg">S/M/L</div>
-                <div class="as-th as-th-arm">A</div>
-                <div class="as-th as-th-str">S</div>
-                <div class="as-th as-th-ov">OV</div>
+                <div class="as-th as-th-name as-th-sortable"
+                     [class.sort-active]="isSortActive('name')"
+                     [class.sort-asc]="filtersService.selectedSortDirection() === 'asc'"
+                     [class.sort-desc]="filtersService.selectedSortDirection() === 'desc'"
+                     (click)="onHeaderSort('name')">Name</div>
+                <div class="as-th as-th-type as-th-sortable"
+                     [class.sort-active]="isSortActive('as.TP')"
+                     [class.sort-asc]="filtersService.selectedSortDirection() === 'asc'"
+                     [class.sort-desc]="filtersService.selectedSortDirection() === 'desc'"
+                     (click)="onHeaderSort('as.TP')">Type</div>
+                <div class="as-th as-th-role as-th-sortable"
+                     [class.sort-active]="isSortActive('role')"
+                     [class.sort-asc]="filtersService.selectedSortDirection() === 'asc'"
+                     [class.sort-desc]="filtersService.selectedSortDirection() === 'desc'"
+                     (click)="onHeaderSort('role')">Role</div>
+                <div class="as-th as-th-pv as-th-sortable"
+                     [class.sort-active]="isSortActive('as.PV')"
+                     [class.sort-asc]="filtersService.selectedSortDirection() === 'asc'"
+                     [class.sort-desc]="filtersService.selectedSortDirection() === 'desc'"
+                     (click)="onHeaderSort('as.PV')">PV</div>
+                <div class="as-th as-th-sz as-th-sortable"
+                     [class.sort-active]="isSortActive('as.SZ')"
+                     [class.sort-asc]="filtersService.selectedSortDirection() === 'asc'"
+                     [class.sort-desc]="filtersService.selectedSortDirection() === 'desc'"
+                     (click)="onHeaderSort('as.SZ')">SZ</div>
+                <div class="as-th as-th-mv as-th-sortable"
+                     [class.sort-active]="isSortActive('as._mv')"
+                     [class.sort-asc]="filtersService.selectedSortDirection() === 'asc'"
+                     [class.sort-desc]="filtersService.selectedSortDirection() === 'desc'"
+                     (click)="onHeaderSort('as._mv')">MV</div>
+                <div class="as-th as-th-tmm as-th-sortable"
+                     [class.sort-active]="isSortActive('as.TMM')"
+                     [class.sort-asc]="filtersService.selectedSortDirection() === 'asc'"
+                     [class.sort-desc]="filtersService.selectedSortDirection() === 'desc'"
+                     (click)="onHeaderSort('as.TMM')">TMM</div>
+                <div class="as-th as-th-dmg as-th-sortable"
+                     [class.sort-active]="isSortActive('as.damage')"
+                     [class.sort-asc]="filtersService.selectedSortDirection() === 'asc'"
+                     [class.sort-desc]="filtersService.selectedSortDirection() === 'desc'"
+                     (click)="onHeaderSort('as.dmg._dmgS', 'as.damage')">S/M/L</div>
+                <div class="as-th as-th-arm as-th-sortable"
+                     [class.sort-active]="isSortActive('as.Arm')"
+                     [class.sort-asc]="filtersService.selectedSortDirection() === 'asc'"
+                     [class.sort-desc]="filtersService.selectedSortDirection() === 'desc'"
+                     (click)="onHeaderSort('as.Arm')">A</div>
+                <div class="as-th as-th-str as-th-sortable"
+                     [class.sort-active]="isSortActive('as.Str')"
+                     [class.sort-asc]="filtersService.selectedSortDirection() === 'asc'"
+                     [class.sort-desc]="filtersService.selectedSortDirection() === 'desc'"
+                     (click)="onHeaderSort('as.Str')">S</div>
+                <div class="as-th as-th-ov as-th-sortable"
+                     [class.sort-active]="isSortActive('as.OV')"
+                     [class.sort-asc]="filtersService.selectedSortDirection() === 'asc'"
+                     [class.sort-desc]="filtersService.selectedSortDirection() === 'desc'"
+                     (click)="onHeaderSort('as.OV')">OV</div>
                 @if (asTableSortSlotHeader(); as sortHeader) {
                 <div class="as-th as-th-sort-slot">{{ sortHeader }}</div>
                 }

--- a/src/app/components/unit-search/unit-search.component.scss
+++ b/src/app/components/unit-search/unit-search.component.scss
@@ -720,6 +720,38 @@
         color: var(--bt-yellow);
     }
 
+    .as-th-sortable {
+        cursor: pointer;
+        user-select: none;
+
+        &:hover {
+            color: var(--text-color-primary, #fff);
+        }
+
+        &.sort-active {
+            color: var(--bt-yellow);
+        }
+
+        &.sort-active::after {
+            content: '';
+            display: inline-block;
+            width: 0;
+            height: 0;
+            margin-left: 4px;
+            vertical-align: middle;
+            border-left: 4px solid transparent;
+            border-right: 4px solid transparent;
+        }
+
+        &.sort-active.sort-asc::after {
+            border-bottom: 5px solid currentColor;
+        }
+
+        &.sort-active.sort-desc::after {
+            border-top: 5px solid currentColor;
+        }
+    }
+
     /* Adjust row items in table view (only when AS table row is visible) */
     .results-dropdown-item:has(.as-table-row) {
         min-height: 48px;

--- a/src/app/components/unit-search/unit-search.component.ts
+++ b/src/app/components/unit-search/unit-search.component.ts
@@ -1106,6 +1106,17 @@ export class UnitSearchComponent {
      * Check if the current sort key matches any of the provided keys or groups.
      * Use in templates: [class.sort-slot]="isSortActive('as.PV')" or isSortActive('as.damage')
      */
+    onHeaderSort(sortKey: string, groupKey?: string): void {
+        const isActive = groupKey ? this.isSortActive(groupKey) : this.isSortActive(sortKey);
+        if (isActive) {
+            const current = this.filtersService.selectedSortDirection();
+            this.filtersService.setSortDirection(current === 'asc' ? 'desc' : 'asc');
+        } else {
+            this.filtersService.setSortOrder(sortKey);
+            this.filtersService.setSortDirection('asc');
+        }
+    }
+
     isSortActive(...keysOrGroups: string[]): boolean {
         const currentSort = this.filtersService.selectedSort();
         if (!currentSort) return false;


### PR DESCRIPTION
Add the ability to click the headers in the Alpha Strike table to sort on that column. 

This feature utilizes the existing sort framework (lower part of the screen). When you click on the header it is reflected in the sort option that is already there. 

Being able to sort by clicking on the header is a common feature in tables, and increases the usability of the table when on devices with larger screens (laptops / desktops)

<img width="1214" height="163" alt="Screenshot 2026-03-06 at 6 12 11 PM" src="https://github.com/user-attachments/assets/714fe8c4-f27f-43a7-9ad6-cd4ab928dbb6" />
