### PR TITLE
feat: Add keybindings for Filter modals when searching for units

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,56 @@ npm run build
 
 This will compile your project and store the build artifacts in the `dist/` directory. By default, the production build optimizes your application for performance and speed.
 
+## Keyboard Shortcuts
+
+### Unit Search
+
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+A` / `Cmd+A` | Select all units |
+| `Escape` | Clear selection / close dialogs |
+
+### Filter Chord Hotkeys
+
+Press `Ctrl+Shift+F` (or `Cmd+Shift+F` on Mac) to activate Filter hotkeys, then press a second key to open the corresponding filter dialog.
+
+Alpha Strike:
+
+| Key | Filter |
+| ----- | -------- |
+| `p` | PV |
+| `m` | Movement |
+| `t` | TMM |
+| `o` | Overheat Value |
+| `a` | Armor |
+| `s` | Structure |
+| `y` | Year |
+| `z` | Size |
+| `h` | Threshold |
+| `1` | Damage (Short) |
+| `2` | Damage (Medium) |
+| `3` | Damage (Long) |
+
+Classic:
+
+| Key | Filter |
+| ----- | -------- |
+| `b` | BV |
+| `t` | Tons |
+| `a` | Armor |
+| `s` | Structure |
+| `f` | Firepower |
+| `d` | Damage/Turn |
+| `h` | Heat |
+| `i` | Dissipation |
+| `e` | Heat Efficiency |
+| `r` | Range |
+| `w` | Walk MP |
+| `u` | Run MP |
+| `j` | Jump MP |
+| `c` | Cost |
+| `y` | Year |
+
 ## Support
 
 For questions, issues, or feature requests, please:

--- a/src/app/components/unit-search/unit-search.component.ts
+++ b/src/app/components/unit-search/unit-search.component.ts
@@ -69,6 +69,7 @@ import { SyntaxInputComponent } from '../syntax-input/syntax-input.component';
 import { SavedSearchesService } from '../../services/saved-searches.service';
 import { generateUUID } from '../../services/ws.service';
 import { GameSystem } from '../../models/common.model';
+import { RANGE_FILTERS } from '../../services/unit-search-filters.model';
 import { UnitDetailsPanelComponent } from '../unit-details-panel/unit-details-panel.component';
 import { UnitCardExpandedComponent } from '../unit-card-expanded/unit-card-expanded.component';
 import { AlphaStrikeCardComponent } from '../alpha-strike-card/alpha-strike-card.component';
@@ -98,7 +99,8 @@ export interface ChassisGroup {
     templateUrl: './unit-search.component.html',
     styleUrl: './unit-search.component.scss',
     host: {
-        '(keydown)': 'onKeydown($event)'
+        '(keydown)': 'onKeydown($event)',
+        '(document:keydown)': 'onDocumentKeydown($event)'
     }
 })
 export class UnitSearchComponent {
@@ -132,6 +134,50 @@ export class UnitSearchComponent {
     private searchDebounceTimer: any;
     private heightTrackingDebounceTimer: any;
     private readonly SEARCH_DEBOUNCE_MS = 300;
+
+    private static readonly CHORD_ACTIVATE_KEY = 'f';
+    private static readonly CHORD_TIMEOUT_MS = 1500;
+    private static readonly FILTER_CHORD_BINDINGS: { key: string; filterKey: string }[] = [
+        // Alpha Strike
+        { key: 'p', filterKey: 'as.PV' },
+        { key: 'm', filterKey: 'as._mv' },
+        { key: 't', filterKey: 'as.TMM' },
+        { key: 'o', filterKey: 'as.OV' },
+        { key: 'a', filterKey: 'as.Arm' },
+        { key: 's', filterKey: 'as.Str' },
+        { key: 'z', filterKey: 'as.SZ' },
+        { key: 'h', filterKey: 'as.Th' },
+        { key: '1', filterKey: 'as.dmg._dmgS' },
+        { key: '2', filterKey: 'as.dmg._dmgM' },
+        { key: '3', filterKey: 'as.dmg._dmgL' },
+        // Classic
+        { key: 'b', filterKey: 'bv' },
+        { key: 't', filterKey: 'tons' },
+        { key: 'a', filterKey: 'armor' },
+        { key: 's', filterKey: 'internal' },
+        { key: 'f', filterKey: '_mdSumNoPhysical' },
+        { key: 'd', filterKey: 'dpt' },
+        { key: 'h', filterKey: 'heat' },
+        { key: 'i', filterKey: 'dissipation' },
+        { key: 'e', filterKey: '_dissipationEfficiency' },
+        { key: 'r', filterKey: '_maxRange' },
+        { key: 'w', filterKey: 'walk' },
+        { key: 'u', filterKey: 'run' },
+        { key: 'j', filterKey: 'jump' },
+        { key: 'c', filterKey: 'cost' },
+        // Both
+        { key: 'y', filterKey: 'year' },
+    ];
+    static resolveChordBinding(key: string, gameSystem: GameSystem): { key: string; filterKey: string } | undefined {
+        return UnitSearchComponent.FILTER_CHORD_BINDINGS.find(b => {
+            if (b.key !== key) return false;
+            const config = RANGE_FILTERS.find(f => f.key === b.filterKey);
+            return config && (!config.game || config.game === gameSystem);
+        });
+    }
+
+    private filterChordActive = false;
+    private filterChordTimer: any;
     /** Reference to the favorites overlay component for in-place updates. */
     private favoritesCompRef: ComponentRef<SearchFavoritesMenuComponent> | null = null;
     /** Flag to track when a favorites dialog (rename/delete) is in progress. */
@@ -881,6 +927,37 @@ export class UnitSearchComponent {
         return Object.values(state).some(s => s.interactedWith) || this.filtersService.bvPvLimit() > 0;
     }
 
+    onDocumentKeydown(event: KeyboardEvent) {
+        // FILTER Chord
+        if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key.toLowerCase() === UnitSearchComponent.CHORD_ACTIVATE_KEY) {
+            event.preventDefault();
+            this.filterChordActive = true;
+            clearTimeout(this.filterChordTimer);
+            this.filterChordTimer = setTimeout(() => this.filterChordActive = false, UnitSearchComponent.CHORD_TIMEOUT_MS);
+            return;
+        }
+
+        // FILTER second key press
+        if (this.filterChordActive) {
+            this.filterChordActive = false;
+            clearTimeout(this.filterChordTimer);
+
+            if (event.ctrlKey || event.metaKey || event.altKey) return;
+
+            const binding = UnitSearchComponent.resolveChordBinding(event.key.toLowerCase(), this.gameSystem());
+            if (!binding) return;
+
+            event.preventDefault();
+            this.expandedView.set(true);
+            this.advOpen.set(true);
+            const currentFilter = this.filtersService.advOptions()[binding.filterKey];
+            if (currentFilter && currentFilter.type === 'range') {
+                this.openRangeValueDialog(binding.filterKey, currentFilter.value, currentFilter.totalRange);
+            }
+            return;
+        }
+    }
+
     onKeydown(event: KeyboardEvent) {
         // SELECT ALL
         if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'a') {
@@ -1114,7 +1191,7 @@ export class UnitSearchComponent {
         'movement': ['walk', 'run', 'jump', 'umu'],
     };
 
-    /** 
+    /**
      * Check if the current sort key matches any of the provided keys or groups.
      * Use in templates: [class.sort-slot]="isSortActive('as.PV')" or isSortActive('as.damage')
      */
@@ -1145,7 +1222,7 @@ export class UnitSearchComponent {
         return false;
     }
 
-    /** 
+    /**
      * Keys always visible in the AS table row.
      * Used by both asTableSortSlotHeader and getAsTableSortSlot.
      */


### PR DESCRIPTION
Improve filtering ergonomics /accessibility when on Desktop / Laptop by providing hot keys to activate filter modals. This helps by allowing a user to use the keyboard for inputting range settings when filtering. 

press `cmd+shift+f` then a second key (within 1.5 seconds) to activate a search modal. A complete list of keys in in the readme.md file. 

Note: I would normally add tests for this, but it doesn't appear that the Karma test harness is working or in place for other components yet (i just saw the scaffold `app.spec.ts` ). Adding that seemed out of scope for this PR, since it isn't in place for other tests. 