### PR TITLE
MH BA fix & Added CC Augmented Forces

### DIFF
--- a/src/app/utils/org-definitions.util.ts
+++ b/src/app/utils/org-definitions.util.ts
@@ -301,7 +301,7 @@ const CLAN_GALAXY: OrgTypeRule = {
 // IS rules
 const IS_FLIGHT: OrgTypeRule = {
     type: 'Flight', modifiers: { 'Under-Strength ': 1, '': 2, 'Reinforced ': 3 },
-    commandRank: 'Lieutenant', tier: 1,
+    commandRank: 'Lieutenant', tier: 1, priority: 1,
     filter: (comp) => isPureAero(comp),
 };
 const IS_SQUADRON: OrgTypeRule = {


### PR DESCRIPTION
New:
- Augmented Lance
  - 4BM+2BA
  - 4BM+2CV
  - 4CV+2BM
- Augmented Company
  - Regular: 2 x Augmented Lance
  - Reinforced: 3 x Augmented Lance
- Augmented Battalion
  - Short: 2 x Augmented Company
  - Under-Strength: 3 x Augmented Company
  - Regular: 4 x Augmented Company
  - Reinforced: 5 x Augmented Company
- Augmented Regiment
  - 3 - 5 Battalions, at least 1 is an Augmented Battalion
 
Known Issues:
- Augmented Lance 4CV+4BA not working (likely due to issues with BA unit handling)