### PR TITLE
fix: allow selecting force packs for copy and paste.

### DIFF
--- a/src/app/components/unit-details-dialog/tabs/unit-details-general-tab.component.html
+++ b/src/app/components/unit-details-dialog/tabs/unit-details-general-tab.component.html
@@ -188,7 +188,7 @@ unit().moveType }}</strong></div>
 </div>
 }
 <div class="spanner"></div>
-<div class="bottom-info">
+<div class="bottom-info allow-select">
 <div class="bottom-left">
 @if (unit().source && unit().source.length > 0) {
 <span class="label muted">Sources:</span>


### PR DESCRIPTION
On the General card for a unit, so that you can select the force pack names, so that you can copy the text, and paste the force pack names to use in a web / amazon / ebay search. 

Fixes a small paper cut so that you don't have to type the force pack names out. 