### PR TITLE
fix: correct tab highlighting

### DIFF
--- a/src/app/components/base-dialog/base-dialog.component.scss
+++ b/src/app/components/base-dialog/base-dialog.component.scss
@@ -169,10 +169,13 @@
         }
     }
 
-    .tab-button:focus-visible:not(.active),
     .tab-button:hover {
         color: var(--text-color);
         border-bottom-color: silver;
+    }
+
+    .tab-button:focus-visible:not(.active) {
+        color: var(--text-color);
     }
 
     .tab-button.active {


### PR DESCRIPTION
Very small UI fix that I noticed. This fixes an issue where:

1. from the first page
2. you select alpha strike
3. type a unit name in (for example, `clint`)
4. click the unit
5. `Card` is highlighted and underlined as the active tab
6. `General` has a silver underline (like you get on hover)

Before:
<img width="655" height="198" alt="Screenshot 2026-03-10 at 9 36 23 AM" src="https://github.com/user-attachments/assets/58b9ce92-24fe-493c-8563-956bdf6e227a" />

After:
<img width="558" height="141" alt="Screenshot 2026-03-10 at 9 47 15 AM" src="https://github.com/user-attachments/assets/2918e70a-0b70-4c8f-b770-7ef0b1e8521f" />

Checked that Classic still highlights `General` correctly

<img width="531" height="226" alt="Screenshot 2026-03-10 at 9 47 46 AM" src="https://github.com/user-attachments/assets/26b06425-345f-4f86-896e-57bca6edc087" />
