### PR TITLE
feat: Add share features to user and public keys

### DIFF
--- a/src/app/components/options-dialog/options-dialog.component.html
+++ b/src/app/components/options-dialog/options-dialog.component.html
@@ -56,6 +56,7 @@
                     <input #uuidInput id="userUuid" class="bt-input" [class.error]="!!userUuidError" type="text"
                         [value]="userUuid()" (focus)="selectAll($event)" (keydown)="onUserUuidKeydown($event)" />
                     <button class="bt-button" (click)="onSetUuid(uuidInput.value)">APPLY</button>
+                    <button class="bt-button" (click)="onShareUuid()">SHARE</button>
                 </div>
                 @if (userUuidError) {<div class="error-msg">{{ userUuidError }}</div>}
                 <div class="description">
@@ -68,6 +69,7 @@
                 <label>Public ID:</label>
                 <div class="option-row">
                     <span class="readonly-value">{{ userPublicId() }}</span>
+                    <button class="bt-button" (click)="onSharePublicId()" [disabled]="userPublicId() === 'Not registered'">SHARE</button>
                 </div>
                 <div class="description">
                     <p>Your Public ID is assigned by the server and can be shared with others to let them subscribe to your public tags.</p>

--- a/src/app/components/options-dialog/options-dialog.component.ts
+++ b/src/app/components/options-dialog/options-dialog.component.ts
@@ -49,6 +49,7 @@ import { PublicTagsService } from '../../services/public-tags.service';
 import { TagsService } from '../../services/tags.service';
 import { TaggingService } from '../../services/tagging.service';
 import { ToastService } from '../../services/toast.service';
+import { copyTextToClipboard } from '../../utils/clipboard.util';
 
 /*
  * Author: Drake
@@ -77,7 +78,7 @@ export class OptionsDialogComponent {
     toastService = inject(ToastService);
     destroyRef = inject(DestroyRef);
     isIOS = isIOS();
-    
+
     tabs = computed(() => {
         return ['General', 'Tags', 'Sheets', 'Alpha Strike', 'Advanced', 'Logs'];
     });
@@ -417,7 +418,7 @@ export class OptionsDialogComponent {
     async onAddSubscription(value: string) {
         this.subscriptionError.set('');
         const trimmed = value.trim();
-        
+
         if (!trimmed) {
             this.subscriptionError.set('Please enter a subscription in the format publicId:tagName');
             return;
@@ -515,5 +516,47 @@ export class OptionsDialogComponent {
 
     async onRenameTag(tagName: string) {
         await this.taggingService.renameTag(tagName);
+    }
+
+    async onShareUuid() {
+        const uuid = this.userUuid();
+        if (!uuid) return;
+
+        const action = await this.dialogsService.choose(
+            'Share User Identifier',
+            '',
+            [
+                { label: 'SHARE', value: 'share' },
+                { label: 'DISMISS', value: 'dismiss' }
+            ],
+            'dismiss',
+            {
+                messageHtml:
+                    '<p>Your User Identifier is a <strong>private key</strong> that controls access to your cloud data.</p>' +
+                    '<p>Only share it with yourself to sync your account across multiple devices.</p>' +
+                    '<strong>Do not share it with other people.</strong></p>'
+            }
+        );
+
+        if (action !== 'share') return;
+        this.shareText(uuid);
+    }
+
+    onSharePublicId() {
+        const publicId = this.userPublicId();
+        if (!publicId || publicId === 'Not registered') return;
+        this.shareText(publicId);
+    }
+
+    private shareText(text: string) {
+        if (navigator.share) {
+            navigator.share({ text }).catch(() => {
+                copyTextToClipboard(text);
+                this.toastService.showToast('Copied to clipboard.', 'success');
+            });
+        } else {
+            copyTextToClipboard(text);
+            this.toastService.showToast('Copied to clipboard.', 'success');
+        }
     }
 }


### PR DESCRIPTION
The purpose of this PR is to improve accessibility around copying keys from the options panel. 

The issue we ran into was that my son was having trouble coping the use id off his phone to sync accounts with a laptop. Being able to bring up the share menu on the phone will improve the UX / Accessibility for syncing account between devices.  

Because the User ID is private, the share button on the User ID pops up a warning to only share it with yourself, and not with other people. 

* Adds a share button to Public key
* Adds a share button to User ID



