### PR TITLE
feat: add optional Force Summary page to AS printing

### DIFF
--- a/src/app/components/options-dialog/options-dialog.component.html
+++ b/src/app/components/options-dialog/options-dialog.component.html
@@ -287,6 +287,14 @@
                     <option value="false">No</option>
                 </select>
             </div>
+            <div class="option-row">
+                <label for="ASPrintRosterSummary">Include roster summary:</label>
+                <select id="ASPrintRosterSummary" class="bt-select" [value]="optionsService.options().ASPrintRosterSummary"
+                    (change)="onASPrintRosterSummaryChange($event)">
+                    <option value="false">No (default)</option>
+                    <option value="true">Yes</option>
+                </select>
+            </div>
             <div class="option-section-title">Rules</div>
             <div class="option-col">
                 <div class="option-row">

--- a/src/app/components/options-dialog/options-dialog.component.ts
+++ b/src/app/components/options-dialog/options-dialog.component.ts
@@ -261,6 +261,11 @@ export class OptionsDialogComponent {
         this.optionsService.setOption('ASPrintPageBreakOnGroups', value);
     }
 
+    onASPrintRosterSummaryChange(event: Event) {
+        const value = (event.target as HTMLSelectElement).value === 'true';
+        this.optionsService.setOption('ASPrintRosterSummary', value);
+    }
+
     onASUnifiedDamagePickerChange(event: Event) {
         const value = (event.target as HTMLSelectElement).value === 'true';
         this.optionsService.setOption('ASUnifiedDamagePicker', value);

--- a/src/app/models/options.model.ts
+++ b/src/app/models/options.model.ts
@@ -63,4 +63,5 @@ export interface Options {
     ASUseAutomations: boolean;
     ASVehiclesCriticalHitTable: 'default' | 'scouringSands';
     ASUnifiedDamagePicker: boolean;
+    ASPrintRosterSummary: boolean;
 }

--- a/src/app/services/force-builder.service.ts
+++ b/src/app/services/force-builder.service.ts
@@ -1366,7 +1366,7 @@ export class ForceBuilderService {
             CBTPrintUtil.multipagePrint(sheetService, optionsService, currentForce.units());
         } else if (currentForce instanceof ASForce) {
             const optionsService = this.injector.get(OptionsService);
-            ASPrintUtil.multipagePrint(appRef, this.injector, optionsService, currentForce.groups(), false, true);
+            ASPrintUtil.multipagePrint(appRef, this.injector, optionsService, currentForce.groups(), false, true, currentForce);
         }
     }
 

--- a/src/app/services/options.service.ts
+++ b/src/app/services/options.service.ts
@@ -65,6 +65,7 @@ const DEFAULT_OPTIONS: Options = {
     ASUseAutomations: true,
     ASVehiclesCriticalHitTable: 'default',
     ASUnifiedDamagePicker: true,
+    ASPrintRosterSummary: false,
 };
 
 @Injectable({ providedIn: 'root' })
@@ -92,6 +93,7 @@ export class OptionsService {
         ASVehiclesCriticalHitTable: DEFAULT_OPTIONS.ASVehiclesCriticalHitTable,
         ASUseAutomations: DEFAULT_OPTIONS.ASUseAutomations,
         ASUnifiedDamagePicker: DEFAULT_OPTIONS.ASUnifiedDamagePicker,
+        ASPrintRosterSummary: DEFAULT_OPTIONS.ASPrintRosterSummary,
     });
 
     constructor() {
@@ -123,6 +125,7 @@ export class OptionsService {
             ASVehiclesCriticalHitTable: saved?.ASVehiclesCriticalHitTable ?? DEFAULT_OPTIONS.ASVehiclesCriticalHitTable,
             ASUseAutomations: saved?.ASUseAutomations ?? DEFAULT_OPTIONS.ASUseAutomations,
             ASUnifiedDamagePicker: saved?.ASUnifiedDamagePicker ?? DEFAULT_OPTIONS.ASUnifiedDamagePicker,
+            ASPrintRosterSummary: saved?.ASPrintRosterSummary ?? DEFAULT_OPTIONS.ASPrintRosterSummary,
         });
     }
 

--- a/src/app/utils/asprint.util.ts
+++ b/src/app/utils/asprint.util.ts
@@ -33,7 +33,7 @@
 
 import { type ApplicationRef, type ComponentRef, createComponent, EnvironmentInjector, type Injector } from '@angular/core';
 import type { ASForceUnit } from '../models/as-force-unit.model';
-import type { UnitGroup } from '../models/force.model';
+import type { Force, UnitGroup } from '../models/force.model';
 import { AlphaStrikeCardComponent } from '../components/alpha-strike-card/alpha-strike-card.component';
 import { getLayoutForUnitType } from '../components/alpha-strike-card/card-layout.config';
 import type { OptionsService } from '../services/options.service';
@@ -80,7 +80,8 @@ export class ASPrintUtil {
         optionsService: OptionsService,
         groups: UnitGroup<ASForceUnit>[],
         clean: boolean = false,
-        triggerPrint: boolean = true
+        triggerPrint: boolean = true,
+        force?: Force
     ): Promise<void> {
         const allUnits = groups.flatMap(g => g.units());
         if (allUnits.length === 0) {
@@ -108,6 +109,13 @@ export class ASPrintUtil {
         const { overlay, cardComponentRefs } = useFixedLayout
             ? await this.createFixedPrintContainer(appRef, injector, optionsService, cardRenderItems, pageBreakOnGroups, groups)
             : await this.createFlexPrintContainer(appRef, injector, optionsService, cardRenderItems, pageBreakOnGroups, groups);
+
+        // Append roster summary page if enabled
+        const printRosterSummary = optionsService.options().ASPrintRosterSummary;
+        if (printRosterSummary && force) {
+            const rosterPage = this.createRosterSummaryPage(groups, force);
+            overlay.appendChild(rosterPage);
+        }
 
         // Wait for fonts and images to load
         if ((document as any).fonts?.ready) {
@@ -539,6 +547,8 @@ export class ASPrintUtil {
                 margin-left: 0.05in;
             }
 
+            ${this.getRosterSummaryStyles()}
+
             @media print {
                 body, html {
                     margin: 0 !important;
@@ -559,6 +569,11 @@ export class ASPrintUtil {
                 .as-print-page.last-page {
                     page-break-after: auto;
                     break-after: auto;
+                }
+
+                .as-roster-summary {
+                    page-break-before: always;
+                    break-before: page;
                 }
 
                 @page {
@@ -629,6 +644,8 @@ export class ASPrintUtil {
                 margin-left: 0.05in;
             }
 
+            ${this.getRosterSummaryStyles()}
+
             @media print {
                 body, html {
                     margin: 0 !important;
@@ -638,12 +655,17 @@ export class ASPrintUtil {
                 body.as-multipage-container-active > *:not(#as-multipage-container) {
                     display: none !important;
                 }
-                
+
                 .as-flex-container.as-group-break {
                     page-break-after: always;
                     break-after: page;
                 }
-                
+
+                .as-roster-summary {
+                    page-break-before: always;
+                    break-before: page;
+                }
+
                 @page {
                     size: auto;
                     margin: 0.25in !important;
@@ -651,6 +673,186 @@ export class ASPrintUtil {
 
             }
         `;
+    }
+
+    /**
+     * Returns shared CSS styles for the roster summary table.
+     */
+    private static getRosterSummaryStyles(): string {
+        return `
+            .as-roster-summary {
+                background: white;
+                padding: 0.2in 0;
+                font-family: sans-serif;
+                color: #222;
+            }
+
+            .as-roster-header {
+                display: flex;
+                align-items: baseline;
+                gap: 0.1in;
+                padding: 0 0.04in 0.08in;
+                border-bottom: 2px solid #333;
+                margin-bottom: 0.1in;
+            }
+
+            .as-roster-faction {
+                font-size: 10pt;
+                color: #555;
+            }
+
+            .as-roster-faction::after {
+                content: ':';
+                margin-left: 2px;
+            }
+
+            .as-roster-force-name {
+                font-size: 12pt;
+                font-weight: 700;
+            }
+
+            .as-roster-table {
+                width: 100%;
+                border-collapse: collapse;
+                font-size: 8pt;
+            }
+
+            .as-roster-table th {
+                font-weight: 700;
+                text-align: left;
+                padding: 2px 4px;
+                border-bottom: 1.5px solid #555;
+                white-space: nowrap;
+            }
+
+            .as-roster-table td {
+                padding: 2px 4px;
+                border-bottom: 0.5px solid #ddd;
+                vertical-align: top;
+                white-space: nowrap;
+            }
+
+            .as-roster-table td.as-roster-specials {
+                font-size: 7pt;
+                color: #555;
+                white-space: normal;
+                max-width: 2.5in;
+            }
+
+            .as-roster-footer {
+                text-align: right;
+                font-weight: 700;
+                font-size: 11pt;
+                margin-top: 0.1in;
+                padding: 0.05in 0.04in;
+                border-top: 2px solid #333;
+            }
+        `;
+    }
+
+    /**
+     * Creates a roster summary page with a table of all units.
+     */
+    private static createRosterSummaryPage(groups: UnitGroup<ASForceUnit>[], force: Force): HTMLElement {
+        const container = document.createElement('div');
+        container.className = 'as-roster-summary';
+
+        // Header
+        const header = document.createElement('div');
+        header.className = 'as-roster-header';
+        const parts: string[] = [];
+        const faction = force.faction();
+        if (faction) {
+            let factionLabel = faction.name;
+            if (faction.group && faction.group !== faction.name) {
+                factionLabel += ` \u00B7 ${faction.group}`;
+            }
+            parts.push(factionLabel);
+        }
+        const era = force.era();
+        if (era) {
+            parts.push(era.name);
+        }
+        if (parts.length > 0) {
+            const factionSpan = document.createElement('span');
+            factionSpan.className = 'as-roster-faction';
+            factionSpan.textContent = parts.join(' \u00B7 ');
+            header.appendChild(factionSpan);
+        }
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'as-roster-force-name';
+        nameSpan.textContent = force.name || '';
+        header.appendChild(nameSpan);
+        container.appendChild(header);
+
+        // Table
+        const table = document.createElement('table');
+        table.className = 'as-roster-table';
+
+        // Table header
+        const thead = document.createElement('thead');
+        const headerRow = document.createElement('tr');
+        const columns = ['Unit', 'TP', 'SZ', 'Skill', 'PV', 'Role', 'MV', 'S', 'M', 'L', 'A+S', 'OV', 'Specials'];
+        for (const col of columns) {
+            const th = document.createElement('th');
+            th.textContent = col;
+            headerRow.appendChild(th);
+        }
+        thead.appendChild(headerRow);
+        table.appendChild(thead);
+
+        // Table body
+        const tbody = document.createElement('tbody');
+        let totalPv = 0;
+
+        for (const group of groups) {
+            for (const forceUnit of group.units()) {
+                const unit = forceUnit.getUnit();
+                const as = unit.as;
+                const adjustedPv = forceUnit.adjustedPv();
+                totalPv += adjustedPv;
+
+                const row = document.createElement('tr');
+
+                const unitName = [unit.chassis, unit.model].filter(Boolean).join(' ');
+                const cells = [
+                    unitName,
+                    as.TP,
+                    String(as.SZ),
+                    String(forceUnit.pilotSkill()),
+                    String(adjustedPv),
+                    unit.role || '',
+                    as.MV,
+                    as.dmg.dmgS,
+                    as.dmg.dmgM,
+                    as.dmg.dmgL,
+                    `${as.Arm}+${as.Str}`,
+                    String(as.OV),
+                    (as.specials || []).join(', ')
+                ];
+
+                for (let i = 0; i < cells.length; i++) {
+                    const td = document.createElement('td');
+                    td.textContent = cells[i];
+                    if (i === columns.length - 1) {
+                        td.className = 'as-roster-specials';
+                    }
+                    row.appendChild(td);
+                }
+
+                tbody.appendChild(row);
+            }
+        }
+        table.appendChild(tbody);
+        container.appendChild(table);
+
+        // Footer with total PV
+        const footer = document.createElement('div');
+        footer.className = 'as-roster-footer';
+        footer.textContent = `Total PV: ${totalPv}`;
+        container.appendChild(footer);
+
+        return container;
     }
 
     /**


### PR DESCRIPTION
Adds an option to add a summary page to the Alpha Strike force printing. 

This is to make it easier to play in local league and shop games where we share force sheets and need to quickly verify Factions, Eras, PV total, and see general list capabilities at a glance. 

Option to add the summary on the Alpha Strike page, under `Printing`

<img width="576" height="205" alt="Screenshot 2026-03-17 at 11 34 52 AM" src="https://github.com/user-attachments/assets/bf8f11a7-6bfc-4f9b-a1dc-522dbf8500e6" />

<img width="491" height="147" alt="Screenshot 2026-03-17 at 11 23 49 AM" src="https://github.com/user-attachments/assets/ca4725fe-8563-4012-b502-11367d1fdd3f" />

Output:

Added to the end of the document:

<img width="221" height="558" alt="Screenshot 2026-03-17 at 11 31 18 AM" src="https://github.com/user-attachments/assets/3505bb4d-3094-41d3-80f2-c6adb9d8c3bf" />

Zoomed in to the summary page

<img width="1059" height="370" alt="Screenshot 2026-03-17 at 11 31 10 AM" src="https://github.com/user-attachments/assets/4153787c-1d19-44e4-852a-faad52619a76" />
