### PR TITLE
Inch or Hex display in Formation Summary

### DIFF
--- a/src/app/components/edit-as-pilot-dialog/ability-dropdown-panel.component.ts
+++ b/src/app/components/edit-as-pilot-dialog/ability-dropdown-panel.component.ts
@@ -32,7 +32,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
-import { type PilotAbility, getAbilityDetails, type PilotAbilityRuleDetails } from '../../models/pilot-abilities.model';
+import { type PilotAbility, getAbilityDetails, hexDisplay, type PilotAbilityRuleDetails } from '../../models/pilot-abilities.model';
 import { GameSystem, formatRulesReference, type RulesReference } from '../../models/common.model';
 import type { ASUnitTypeCode } from '../../models/units.model';
 
@@ -228,7 +228,7 @@ export class AbilityDropdownPanelComponent {
             return {
                 ability,
                 details,
-                summary: details.summary[0] ?? '',
+                summary: hexDisplay(details.summary)[0] ?? '',
                 rulesRef: details.rulesRef ?? [],
                 unitTypeRestricted,
                 unitTypeLabel: details.unitType,

--- a/src/app/components/edit-as-pilot-dialog/edit-as-pilot-dialog.component.ts
+++ b/src/app/components/edit-as-pilot-dialog/edit-as-pilot-dialog.component.ts
@@ -34,7 +34,7 @@
 import { ChangeDetectionStrategy, Component, ElementRef, inject, signal, viewChild, computed, DestroyRef, Injector } from '@angular/core';
 import { DialogRef, DIALOG_DATA } from '@angular/cdk/dialog';
 import { ComponentPortal } from '@angular/cdk/portal';
-import { PILOT_ABILITIES, type PilotAbility, type ASCustomPilotAbility, getAbilityLimitsForSkill, type PilotAbilityLimits, getAbilityDetails } from '../../models/pilot-abilities.model';
+import { PILOT_ABILITIES, type PilotAbility, type ASCustomPilotAbility, getAbilityLimitsForSkill, type PilotAbilityLimits, getAbilityDetails, hexDisplay } from '../../models/pilot-abilities.model';
 import type { ASForceUnit } from '../../models/as-force-unit.model';
 import { COMMAND_ABILITIES } from '../../models/command-abilities.model';
 import type { UnitGroup } from '../../models/force.model';
@@ -358,7 +358,7 @@ export class EditASPilotDialogComponent {
         return {
             name: standardAbility.name,
             cost: standardAbility.cost,
-            summary: details.summary[0],
+            summary: hexDisplay(details.summary)[0],
             isCustom: false,
             rulesRef: details.rulesRef,
             unitTypeInvalid

--- a/src/app/components/formation-info/formation-info.component.ts
+++ b/src/app/components/formation-info/formation-info.component.ts
@@ -34,7 +34,7 @@
 import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
 import type { FormationTypeDefinition, FormationEffectGroup } from '../../utils/formation-type.model';
 import { FORMATION_DEFINITIONS } from '../../utils/formation-definitions';
-import { type PilotAbility, PILOT_ABILITIES, getAbilityDetails } from '../../models/pilot-abilities.model';
+import { type PilotAbility, PILOT_ABILITIES, getAbilityDetails, hexDisplay } from '../../models/pilot-abilities.model';
 import { type CommandAbility, COMMAND_ABILITIES } from '../../models/command-abilities.model';
 import { GameSystem, formatRulesReference, type RulesReference } from '../../models/common.model';
 import { getInheritedFormationEffectGroups } from '../../utils/formation-ability-assignment.util';
@@ -521,7 +521,7 @@ export class FormationInfoComponent {
                         abilities.push({
                             pilotAbility: pilot,
                             name: pilot.name,
-                            summary: details.summary,
+                            summary: hexDisplay(details.summary),
                             rulesRef: details.rulesRef ?? [],
                             unitType: details.unitType,
                         });

--- a/src/app/models/common.model.ts
+++ b/src/app/models/common.model.ts
@@ -44,6 +44,7 @@ export enum Rulebook {
     ASC_ERR16 = "Alpha Strike Companion Errata v1.6 (2022)",
     BOT = "Battle of Tukayyid",
     CO = "BattleTech: Campaign Operations"
+    FMK = "Force Manual: Kurita"
 }
 
 /**

--- a/src/app/models/pilot-abilities.model.ts
+++ b/src/app/models/pilot-abilities.model.ts
@@ -34,6 +34,16 @@
 import { Rulebook, type RulesReference } from './common.model';
 import { GameSystem } from '../models/common.model';
 import type { ASUnitTypeCode } from './units.model';
+import { OptionsService } from '../services/options.service';
+
+export function hexDisplay(summaries: string[]): string[] {
+    const useHex = OptionsService.get()?.options()?.ASUseHex ?? false;
+    return summaries.map(text => {
+        return text.replace(/\[\[(\d+)\]\]/g, (_, val) => {
+            return useHex ? `${Math.floor(val) / 2}⬢` : `${val}″`;
+        });
+    });
+}
 
 /** Game-system-specific details for a pilot ability */
 export interface PilotAbilityRuleDetails {
@@ -122,7 +132,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 92 }],
             unitType: "'Mechs, ProtoMechs",
             unitTypeFilter: ['BM', 'IM', 'PM'],
-            summary: ["Reduces Move cost for ultra-heavy woods, ultra-heavy jungle, and buildings by 2\" per inch. During Combat Phase, may intimidate one enemy within medium range and LOS (2D6 roll, TN 8 + Skill \u2013 SZ); success subtracts 2\" MV, 1 TMM (min 2\"/0 TMM) and applies +1 TN for attacks against this unit. Lasts through End Phase of next turn."],
+            summary: ["Reduces Move cost for ultra-heavy woods, ultra-heavy jungle, and buildings by [[2]] per [[1]]. During Combat Phase, may intimidate one enemy within medium range and LOS (2D6 roll, TN 8 + Skill \u2013 SZ); success subtracts [[2]] MV, 1 TMM (min [[2]]/0 TMM) and applies +1 TN for attacks against this unit. Lasts through End Phase of next turn."],
             description: [
                 "The pilot with this SPA has combined an exceptional understanding of animal behavior with their own natural aptitude at the controls to give the movements of their machine an uncanny\u2014even frightening\u2014resemblance to that of a wild animal.",
                 "This ability, which works only with 'Mech and ProtoMech units where the model has four legs, reduces the unit's Move cost for passing through ultra-heavy woods terrain, ultra-heavy jungle terrain, or any buildings by 2 inches per inch of movement.",
@@ -148,7 +158,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
         },
         as: {
             rulesRef: [{ book: Rulebook.ASCE, page: 92 }],
-            summary: ["During Combat Phase, in place of attack, may enrage one enemy within short range (2D6 roll, TN 5 + Skill). Enraged unit must move toward Antagonizer by most direct route, ignoring terrain costs, and can only attack the Antagonizer. Effect lasts through End Phase of next turn. Breaks if enraged unit begins any phase more than 24\" away or without LOS. No effect vs. aerospace units."],
+            summary: ["During Combat Phase, in place of attack, may enrage one enemy within short range (2D6 roll, TN 5 + Skill). Enraged unit must move toward Antagonizer by most direct route, ignoring terrain costs, and can only attack the Antagonizer. Effect lasts through End Phase of next turn. Breaks if enraged unit begins any phase more than [[24]] away or without LOS. No effect vs. aerospace units."],
             description: [
                 "As combat talents go, the ability to enrage the enemy may seem ill-conceived at first, but few can overstate how effective it is when it draws fire from a wounded friend\u2014or exposes the berserking target's weaker back armor at the worst possible moment.",
                 "During the Combat Phase, in place of the unit's attack, the player may select one enemy unit within short range of this unit to try to enrage. The Antagonizer unit must make a 2D6 roll, with a target number of 5 + their Skill. Success will enrage the target. The enrage takes effect in the End Phase of this turn and lasts through the End Phase of the next turn.",
@@ -247,7 +257,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 93 }],
             unitType: "Ground Vehicles",
             unitTypeFilter: ['CV', 'SV'],
-            summary: ["Ground vehicle may enter woods, rough, rubble, or water terrain up to 1\" deep even if normally prohibited. Move costs for these terrains are double the cost for a 'Mech unit."],
+            summary: ["Ground vehicle may enter woods, rough, rubble, or water terrain up to [[1]] deep even if normally prohibited. Move costs for these terrains are double the cost for a 'Mech unit."],
             description: [
                 "The vehicle driver with this SPA is not merely able to get their ride into and out of tight spots; they can get it into some places it's just not meant to enter!",
                 "This ground unit may enter woods, rough, or rubble terrain, as well as water terrain up to 1 inch deep, even if the vehicle's movement type would ordinarily prohibit such movement. When entering terrain ordinarily prohibited to the unit, consider all Move costs for these terrains as double the cost to traverse as they would be for a 'Mech unit.",
@@ -271,7 +281,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
         },
         as: {
             rulesRef: [{ book: Rulebook.ASCE, page: 93 }],
-            summary: ["During Combat Phase, may intimidate one enemy within LOS and medium range (2D6 roll, TN 8 + Skill \u2013 SZ). Success subtracts 2\" MV, 1 TMM (min 2\"/0 TMM) and applies +1 TN for attacks against the Demoralizer. Lasts through End Phase of next turn. Breaks if target begins any phase more than 24\" away or without LOS. No effect vs. aerospace units."],
+            summary: ["During Combat Phase, may intimidate one enemy within LOS and medium range (2D6 roll, TN 8 + Skill \u2013 SZ). Success subtracts [[2]] MV, 1 TMM (min [[2]]/0 TMM) and applies +1 TN for attacks against the Demoralizer. Lasts through End Phase of next turn. Breaks if target begins any phase more than [[24]] away or without LOS. No effect vs. aerospace units."],
             description: [
                 "A warrior with the Demoralizer SPA can make their unit a holy terror on the battlefield, projecting an intimidating presence that manifests in the way they maneuver and taunt their enemies\u2014with or without the use of communications.",
                 "During the Combat Phase, the player may select one enemy unit within line of sight and within medium range of this unit to try to intimidate. The Demoralizer unit must make a 2D6 roll, with a target number of 8 + the Demoralizer's Skill \u2013 the Demoralizer's SZ. Success will intimidate the target.",
@@ -348,7 +358,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
         },
         as: {
             rulesRef: [{ book: Rulebook.ASCE, page: 95 }],
-            summary: ["Adds 2\" detection range to any probe specials (BH, PRB, LPRB). Confers RCN special even if not normally possessed. Hidden units within 2\" are automatically detected, ignoring ECM specials (AECM, ECM, LECM). Adds +2 TN to avoid minefield attacks."],
+            summary: ["Adds [[2]] detection range to any probe specials (BH, PRB, LPRB). Confers RCN special even if not normally possessed. Hidden units within [[2]] are automatically detected, ignoring ECM specials (AECM, ECM, LECM). Adds +2 TN to avoid minefield attacks."],
             description: [
                 "For some warriors, even thirty-first century sensors are superfluous. The warrior with this SPA is so alert and sensor-savvy that they can practically identify threats before their tactical computers can identify them, a vital edge in spotting hidden surprises before it's too late.",
                 "This unit adds 2 inches of detection range to any probe special abilities it already possesses (including BH, PRB, and LPRB), and confers the RCN special to the unit even if it does not possess such abilities normally.",
@@ -371,7 +381,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
         },
         as: {
             rulesRef: [{ book: Rulebook.ASCE, page: 95 }],
-            summary: ["Specify one Environmental Condition before the scenario. Reduces additional Move costs from that condition by 2\" (min +0\") and reduces Target Number modifiers from that condition by \u20131 (min +0)."],
+            summary: ["Specify one Environmental Condition before the scenario. Reduces additional Move costs from that condition by [[2]] (min +[[0]]) and reduces Target Number modifiers from that condition by \u20131 (min +0)."],
             description: [
                 "The pilot with the Environmental Specialist SPA has not only learned how to survive in a harsh environment, but can actually thrive in it. This ability specifically focuses on atmospheric and weather aspects of a given environment (as opposed to terrain mastery), and the nature of this specialization must be identified when assigned.",
                 "The conditions that apply to this SPA must be specified for this unit before the scenario begins, and may include any one condition described under Environmental Conditions. If the given environmental condition applies to the scenario, this reduces any additional Move costs created by that condition by 2 inches (to a minimum of +0 inches), and any Target Number modifiers applied by the condition are also reduced by \u20131 (to a minimum of +0).",
@@ -521,7 +531,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 96 }],
             unitType: "VTOLs, Fighters, Small Craft",
             unitTypeFilter: ['CV', 'SV', 'AF', 'CF', 'SC'],
-            summary: ["Can execute a 'double strafe' (two strafing areas, each at least 2\" long, total 10\") or a 'double strike' (two strike attacks in a single pass). All attacks must be along the unit's flight path."],
+            summary: ["Can execute a 'double strafe' (two strafing areas, each at least [[2]] long, total [[10]]) or a 'double strike' (two strike attacks in a single pass). All attacks must be along the unit's flight path."],
             description: [
                 "Another special skill for ace aviators, the Ground-Hugger SPA reflects a pilot whose fast reflexes and sense of timing enable them to deliver more damage in a single pass than most others.",
                 "When resolving air-to-ground combat rules the pilot with this SPA can execute either a 'double strafe', or a 'double strike' attack in a single ground-attack pass. The double strafe attack allows the unit to break its normal 10-inch strafing run into two strafing areas, each at least 2 inches long (and 2 inches wide), with a total combined strafe line of 10 inches.",
@@ -561,7 +571,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 97 }],
             unitType: "'Mechs",
             unitTypeFilter: ['BM', 'IM'],
-            summary: ["Adds 1 level to the max Size of cargo/units the 'Mech can lift, drag, or throw (External Cargo Carriers rules). If this exceeds Size 5, can lift LG cargo; if LG already included, can lift VLG. If cargo is more than 3 Sizes smaller than the 'Mech, movement is only reduced by 2\" instead of by half."],
+            summary: ["Adds 1 level to the max Size of cargo/units the 'Mech can lift, drag, or throw (External Cargo Carriers rules). If this exceeds Size 5, can lift LG cargo; if LG already included, can lift VLG. If cargo is more than 3 Sizes smaller than the 'Mech, movement is only reduced by [[2]] instead of by half."],
             description: [
                 "The Heavy Lifter is a MechWarrior or IndustrialMech pilot who has mastered the finer points of balance and control when using their machine to lift and carry external cargo.",
                 "With this SPA, the unit adds 1 level to the maximum Size of any cargo (or units) their 'Mech can lift, drag, or throw using the External Cargo Carriers rules. If this would exceed a Size of 5, the unit can lift cargo or units that also have the LG special. If the maximum Size allowance already includes the LG special, the unit can lift Very Large cargo or units (VLG).",
@@ -613,7 +623,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 97 }],
             unitType: "'Mechs, Aerospace Fighters",
             unitTypeFilter: ['BM', 'IM', 'AF'],
-            summary: ["Unit acts as if one level lower on the Heat scale. Can sustain 4 points of Heat before auto-shutdown instead of 3. At 4 Heat: loses 6\" ground MV, \u20131 TMM (min 0), and +3 TN modifier instead of shutting down."],
+            summary: ["Unit acts as if one level lower on the Heat scale. Can sustain 4 points of Heat before auto-shutdown instead of 3. At 4 Heat: loses [[6]] ground MV, \u20131 TMM (min 0), and +3 TN modifier instead of shutting down."],
             description: [
                 "This MechWarrior or fighter pilot knows how to ride the heat envelope.",
                 "The unit acts as if it was one level lower on the Heat scale, and can sustain 4 points of Heat before automatically shutting down rather than the usual 3. At 4 points of Heat, the unit loses 6\" of ground movement, subtracts 1 from its target movement modifier (minimum TMM of 0), and suffers a +3 Target Number modifier instead of shutting down.",
@@ -635,7 +645,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
         },
         as: {
             rulesRef: [{ book: Rulebook.ASCE, page: 97 }],
-            summary: ["If Concealing Unit Data rules are in play, automatically identifies any non-hidden unit within 12\", revealing its data card as if the unit has LPRB (does not reveal hidden units). Once per game, may declare before rolling to hit: if the attack hits, make an additional Critical Hit check against the target."],
+            summary: ["If Concealing Unit Data rules are in play, automatically identifies any non-hidden unit within [[12]], revealing its data card as if the unit has LPRB (does not reveal hidden units). Once per game, may declare before rolling to hit: if the attack hits, make an additional Critical Hit check against the target."],
             description: [
                 "Everyone has a hobby; this one's happens to be memorizing the specs for thousands of 'Mechs\u2014and they won't let you forget it!",
                 "If the Concealing Unit Data rules are in play, this unit will automatically identify any non-hidden unit within 12 inches, revealing the subject's data card as if the Human TRO's unit has the LPRB special. This ability applies even if the Human TRO's unit does not have an active probe of any kind, but it does not confer the ability to reveal hidden units.",
@@ -798,7 +808,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
         },
         as: {
             rulesRef: [{ book: Rulebook.ASCE, page: 97 }],
-            summary: ["Reduces Move cost through all woods and jungle terrain types by 1\" per inch of movement. For aerospace units, reduces the Control Roll target modifier for atmospheric combat from +2 to +1."],
+            summary: ["Reduces Move cost through all woods and jungle terrain types by [[1]] per [[1]] of movement. For aerospace units, reduces the Control Roll target modifier for atmospheric combat from +2 to +1."],
             description: [
                 "This pilot knows how to get their ride into and out of tight spots in a hurry.",
                 "This unit reduces the cost for moving through all woods and jungle terrain types by 1 inch per inch of movement. For aerospace units, a pilot with this SPA reduces the unit's Control Roll target modifier for atmospheric combat from +2 to +1.",
@@ -919,7 +929,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 98 }],
             unitType: "'Mechs, ProtoMechs",
             unitTypeFilter: ['BM', 'IM', 'PM'],
-            summary: ["Unit may attack as if it has a 360-degree firing arc (still suffers 1 extra damage if attacked through rear facing). Reduces Move cost for ultra-heavy woods, ultra-heavy jungle, and buildings by 1\" per inch of movement."],
+            summary: ["Unit may attack as if it has a 360-degree firing arc (still suffers 1 extra damage if attacked through rear facing). Reduces Move cost for ultra-heavy woods, ultra-heavy jungle, and buildings by [[1]] per [[1]] of movement."],
             description: [
                 "They just don't teach the piloting skills this warrior can demonstrate in the normal academies!",
                 "This unit may make attacks as if it has a 360-degree firing arc (but still suffers 1 additional damage point if attacked through the rear facing). It also reduces its Move cost for passing through ultra-heavy woods terrain, ultra-heavy jungle terrain, or any buildings by 1 inch per inch of movement.",
@@ -1106,7 +1116,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 99 }],
             unitType: "'Mechs",
             unitTypeFilter: ['BM', 'IM'],
-            summary: ["Unit can obtain an improvised melee weapon by spending 2\" extra movement in woods, jungle, rubble, or building terrain (no roll required, declared during Movement). After obtaining the weapon, may execute physical attacks as if it has the MEL special. No effect if the unit already has MEL."],
+            summary: ["Unit can obtain an improvised melee weapon by spending [[2]] extra movement in woods, jungle, rubble, or building terrain (no roll required, declared during Movement). After obtaining the weapon, may execute physical attacks as if it has the MEL special. No effect if the unit already has MEL."],
             description: [
                 "Some 'Mechs have built-in swords and hatchets to fight with, but this MechWarrior knows how to improvise their own.",
                 "This unit can make use of an improvised melee weapon by simply spending 2 extra inches of movement in a woods, jungle, rubble, or building terrain to find an appropriate weapon. This action requires no roll and creates no special modifiers, but must be declared during the unit's Movement Phase.",
@@ -1148,7 +1158,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
         },
         as: {
             rulesRef: [{ book: Rulebook.ASCE, page: 99 }],
-            summary: ["Ground units receive +2\" Move per turn and +4\" Sprinting movement (does not change TMM). Aerospace units receive an effective Thrust value 1 point higher than listed on their stat card."],
+            summary: ["Ground units receive +[[2]] Move per turn and +[[4]] Sprinting movement (does not change TMM). Aerospace units receive an effective Thrust value 1 point higher than listed on their stat card."],
             description: [
                 "A pilot with the Speed Demon SPA can really pour it on!",
                 "Ground units of all motive types (including VTOLs and WiGE vehicles) receive an additional 2 inches of Move per turn when driven by a pilot with this ability, and increase their Sprinting movement by 4 inches per turn. This speed boost will not change the unit's target movement modifier, however.",
@@ -1172,7 +1182,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
         },
         as: {
             rulesRef: [{ book: Rulebook.ASCE, page: 99 }],
-            summary: ["Unit can move through hostile units during Movement Phase at +1\" Move cost, causing no damage to either unit. Also immune to the maneuver-limiting effects of any opposing unit's Zone of Control command ability."],
+            summary: ["Unit can move through hostile units during Movement Phase at +[[1]] Move cost, causing no damage to either unit. Also immune to the maneuver-limiting effects of any opposing unit's Zone of Control command ability."],
             description: [
                 "This unit can move through hostile units during its Movement Phase, at an additional cost of 1 inch of Move. This action causes no damage to either unit; it simply negates the normal 'stacking restriction' that prevents units from moving directly through enemy-occupied positions on the map.",
                 "Zone of Control: A unit piloted by a warrior with this SPA is also immune to the maneuver-limiting effects of any opposing unit using the Zone of Control special command ability against it.",
@@ -1215,7 +1225,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 100 }],
             unitType: "'Mechs, ProtoMechs",
             unitTypeFilter: ['BM', 'IM', 'PM'],
-            summary: ["Receives +2\" Move on paved or ice terrain (plus normal pavement bonus). Sprinting adds +4\" instead. If Skidding rules are in play, applies \u20132 TN to the unit's Control Roll."],
+            summary: ["Receives +[[2]] Move on paved or ice terrain (plus normal pavement bonus). Sprinting adds +[[4]] instead. If Skidding rules are in play, applies \u20132 TN to the unit's Control Roll."],
             description: [
                 "This unit receives an additional 2 inches to its normal movement allowance any turn it remains entirely on paved or ice terrain (in addition to the normal pavement movement bonus). If Sprinting movement is used, the Sure-Footed unit adds 4 inches (plus any pavement bonus) as long as the unit remains on the paved or ice terrain.",
                 "Furthermore, if the Skidding rules are in play, the Sure-Footed SPA applies a \u20132 Target Number modifier to the unit's Control Roll.",
@@ -1289,7 +1299,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 100 }],
             unitType: "Combat Vehicles (tracked or wheeled)",
             unitTypeFilter: ['CV'],
-            summary: ["Receives +4\" Move on paved or ice terrain (plus normal pavement bonus). Sprinting adds +6\" instead. If Skidding rules are in play, applies \u20132 TN to the unit's Control Roll."],
+            summary: ["Receives +[[4]] Move on paved or ice terrain (plus normal pavement bonus). Sprinting adds +[[6]] instead. If Skidding rules are in play, applies \u20132 TN to the unit's Control Roll."],
             description: [
                 "A vehicle driver with this SPA isn't just a speed demon; he's practically a professional racer.",
                 "This unit receives an additional 4 inches to its normal movement allowance any turn it remains entirely on paved or ice terrain (in addition to the normal pavement movement bonus). If Sprinting movement is used, the Drag Racer adds 6 inches (plus any pavement bonus) as long as their vehicle remains on the paved or ice terrain.",
@@ -1315,7 +1325,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 100 }],
             unitType: "Any non-airborne unit",
             unitTypeFilter: ['BM', 'IM', 'PM', 'CV', 'SV', 'BA', 'CI'],
-            summary: ["Reduces additional Move costs through woods/jungle terrain (including heavy and ultra-heavy) by 1\" per inch of movement (min +0\"). Attacks against this unit suffer +1 Terrain Modifier if it ends movement in wooded or jungle terrain."],
+            summary: ["Reduces additional Move costs through woods/jungle terrain (including heavy and ultra-heavy) by [[1]] per [[1]] of movement (min +[[0]]). Attacks against this unit suffer +1 Terrain Modifier if it ends movement in wooded or jungle terrain."],
             description: [
                 "This warrior with this ability is truly at home in woodlands.",
                 "A unit piloted by a warrior with this SPA reduces its additional Move costs when travelling through woods or jungle terrain (including heavy and ultra-heavy woods and jungle) by 1 inch per inch of movement (to a minimum added cost of +0 inches).",
@@ -1341,7 +1351,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 100 }],
             unitType: "'Mechs, ProtoMechs",
             unitTypeFilter: ['BM', 'IM', 'PM'],
-            summary: ["Reduces movement costs for underwater movement by 1\" per inch of travel (min +0\"). Only applies when fully submerged."],
+            summary: ["Reduces movement costs for underwater movement by [[1]] per [[1]] of travel (min +[[0]]). Only applies when fully submerged."],
             description: [
                 "This MechWarrior or ProtoMech pilot is uncommonly good at maneuvering their machine underwater, even without the benefits of UMU mobility.",
                 "This SPA reduces the unit's movement costs for underwater movement by 1 inch per inch of travel, to a minimum added Move cost of +0 inches. This benefit only applies when the unit is fully submerged.",
@@ -1366,7 +1376,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 100 }],
             unitType: "Any non-airborne unit",
             unitTypeFilter: ['BM', 'IM', 'PM', 'CV', 'SV', 'BA', 'CI'],
-            summary: ["Reduces additional Move costs for changing levels, Climbing, or passing through rough/rubble terrain (including ultra-rough/ultra-rubble) by 1\" per inch of travel (min +0\")."],
+            summary: ["Reduces additional Move costs for changing levels, Climbing, or passing through rough/rubble terrain (including ultra-rough/ultra-rubble) by [[1]] per [[1]] of travel (min +[[0]])."],
             description: [
                 "The Mountaineer is a warrior or vehicle pilot who has an affinity for steep slopes and rocks.",
                 "This SPA reduces the additional Move costs for changing levels, using Climbing movement, or for passing through rough and rubble terrain types (including ultra-rough and ultra-rubble) by 1 inch per inch of travel, to a minimum added Move cost of +0 inches.",
@@ -1406,7 +1416,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 101 }],
             unitType: "Any non-airborne unit",
             unitTypeFilter: ['BM', 'IM', 'PM', 'CV', 'SV', 'BA', 'CI'],
-            summary: ["Reduces additional Move costs for water terrain by 1\" per inch of travel (min +0\"). Attacks against this unit suffer +1 Terrain Modifier while in water terrain of depth 1\"\u20132\". Ignores the +1 underwater terrain modifier when attacking."],
+            summary: ["Reduces additional Move costs for water terrain by [[1]] per [[1]] of travel (min +[[0]]). Attacks against this unit suffer +1 Terrain Modifier while in water terrain of depth [[1]]\u2013[[2]]. Ignores the +1 underwater terrain modifier when attacking."],
             description: [
                 "This unit reduces the additional Move costs for passing through water terrain by 1 inch per inch of travel, to a minimum added cost of +0 inches.",
                 "In addition to this, attacks against this pilot's unit will suffer an additional +1 Terrain Modifier as long as the unit is occupying water terrain of depth 1\"\u20132\". The Sea Monster ignores the +1 underwater terrain modifier when it is attacking.",
@@ -1431,7 +1441,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 101 }],
             unitType: "Any non-airborne unit",
             unitTypeFilter: ['BM', 'IM', 'PM', 'CV', 'SV', 'BA', 'CI'],
-            summary: ["Reduces additional Move costs for swamp terrain by 1\" per inch of travel (min +0\"). Ignores Bogging Down rules in mud/swamp terrain. Attacks against this unit suffer +1 Terrain Modifier while in mud or swamp terrain."],
+            summary: ["Reduces additional Move costs for swamp terrain by [[1]] per [[1]] of travel (min +[[0]]). Ignores Bogging Down rules in mud/swamp terrain. Attacks against this unit suffer +1 Terrain Modifier while in mud or swamp terrain."],
             description: [
                 "Terrain masters have honed their piloting skills under particularly treacherous conditions; the 'swamp beast' knows how to handle mud, marsh\u2014even quicksand, if it comes up.",
                 "This unit reduces the additional Move costs for passing through swamp terrain by 1 inch per inch of travel, to a minimum added cost of +0 inches. In addition to this, the Swamp Beast ignores the Bogging Down rules when traveling through mud or swamp terrain.",
@@ -1531,7 +1541,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 101 }],
             unitType: "CI (beast-mounted only)",
             unitTypeFilter: ['CI'],
-            summary: ["Beast-mounted infantry receives +2\" Move per turn and reduces additional movement costs for wooded or rough terrain by 1\" per inch of travel (min +0\")."],
+            summary: ["Beast-mounted infantry receives +[[2]] Move per turn and reduces additional movement costs for wooded or rough terrain by [[1]] per [[1]] of travel (min +[[0]])."],
             description: [
                 "Yes, it may be the future, but that doesn\u2019t mean horse (or horse-analog) infantry doesn\u2019t still exist\u2014or that there aren\u2019t troops out there who specialize in their use.",
                 "A beast-mounted infantry unit with this SPA receives an additional 2 inches of movement per turn, and reduces the additional movement costs for wooded or rough terrain types by 1 inch per inch of travel (to a minimum added movement cost of +0 inches).",
@@ -1580,7 +1590,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 101 }],
             unitType: "CI (foot motive type only)",
             unitTypeFilter: ['CI'],
-            summary: ["Foot infantry receives +2\" Move per turn, reduces additional movement costs for woods, jungle, rough, rubble, and building terrain by 1\" per inch of travel, and halves elevation change costs (min +0\")."],
+            summary: ["Foot infantry receives +[[2]] Move per turn, reduces additional movement costs for woods, jungle, rough, rubble, and building terrain by [[1]] per [[1]] of travel, and halves elevation change costs (min +[[0]])."],
             description: [
                 "The foot cavalry\u2019s squad leader has trained for endurance running, even in full combat gear\u2014and pushes their troops hard to keep them up to their level.",
                 "A conventional foot infantry unit with this SPA receives an additional 2 inches of movement per turn, and reduces the additional movement costs for all wooded, jungle, rough, rubble, and building terrain types by 1 inch per inch of travel and halves the elevation change movement costs (to a minimum added movement cost of +0 inches).",
@@ -1606,7 +1616,7 @@ export const PILOT_ABILITIES: PilotAbility[] = [
             rulesRef: [{ book: Rulebook.ASCE, page: 101 }],
             unitType: "CI, BA",
             unitTypeFilter: ['CI', 'BA'],
-            summary: ["Attacks against this infantry unit suffer +1 TN and \u20131 damage if in building, rough, rubble, or paved terrain. Once per urban scenario, may spawn a friendly CI unit (2\" Move, 1 armor, 1 structure, 1 damage at Short range, Skill +2) within 6\"."],
+            summary: ["Attacks against this infantry unit suffer +1 TN and \u20131 damage if in building, rough, rubble, or paved terrain. Once per urban scenario, may spawn a friendly CI unit ([[2]] Move, 1 armor, 1 structure, 1 damage at Short range, Skill +2) within [[6]]."],
             description: [
                 "Nobody knows the streets like this infantry force\u2014but is this really a regular outfit, or a street gang?",
                 "Attacks against an infantry unit with this SPA suffer a +1 Target Number modifier, and a \u20131 damage point reduction if the unit is occupying building, rough, rubble, or paved terrain types.",

--- a/src/app/services/options.service.ts
+++ b/src/app/services/options.service.ts
@@ -80,6 +80,7 @@ const DEFAULT_OPTIONS: Options = {
 
 @Injectable({ providedIn: 'root' })
 export class OptionsService {
+    private static instance: OptionsService;
     private dbService = inject(DbService);
 
     public options = signal<Options>({
@@ -117,6 +118,7 @@ export class OptionsService {
     });
 
     constructor() {
+        OptionsService.instance = this;
         this.initOptions();
     }
 
@@ -163,5 +165,9 @@ export class OptionsService {
         const updated = { ...this.options(), [key]: value };
         this.options.set(updated);
         await this.dbService.saveOptions(updated);
+    }
+
+    static get(): OptionsService {
+        return OptionsService.instance;
     }
 }

--- a/src/app/utils/formation-definitions.ts
+++ b/src/app/utils/formation-definitions.ts
@@ -241,7 +241,7 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         description: 'All infantry units for urban and anti-mech warfare',
         effectDescription: 'Distracting Swarm: units in this formation swarming an enemy unit cause a +1 To-Hit modifier to any weapon attacks made by the enemy unit.',
         minUnits: 3,
-        rulesRef: [{ book: Rulebook.CO, page: 61 }],
+        rulesRef: [{ book: Rulebook.CO, page: 61 }, { book: Rulebook.CO, page: 87 }],
         requirements: () => {
             const infantry = isAS ? ' (CI, BA, or PM)': '';
             return `Minimum 3 units. All units must be Infantry${infantry}.`;
@@ -465,7 +465,7 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
             distribution: 'shared-pool',
         }],
         minUnits: 3,
-        rulesRef: [{ book: Rulebook.CO, page: 62 }, { book: Rulebook.ASCE, page: 117 }],
+        rulesRef: [{ book: Rulebook.CO, page: 63 }, { book: Rulebook.ASCE, page: 117 }],
         requirements: () => {
             const lightNoAssault = isAS ? 'Size 1. No Size 4+' : 'light. No assault';
             const light = isAS ? 'Size 1' : 'light';
@@ -500,7 +500,7 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
             distribution: 'shared-pool',
         }],
         minUnits: 3,
-        rulesRef: [{ book: Rulebook.CO, page: 62 }, { book: Rulebook.ASCE, page: 117 }],
+        rulesRef: [{ book: Rulebook.CO, page: 63 }, { book: Rulebook.ASCE, page: 117 }],
         requirements: () => {
             const mediumNoAssault = isAS ? 'Size 2. No Size 4+' : 'medium. No assault';
             const medium = isAS ? 'Size 2' : 'medium';
@@ -611,7 +611,6 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
     {
         id: 'berserker-lance',
         name: 'Berserker/Close Combat',
-        parent: 'battle-lance',
         nameAliases: ['Berserker', 'Close Combat'],
         description: 'Close combat specialists for physical attacks',
         effectDescription: 'Two units in this formation receive the Swordsman or Zweihander SPA. The same ability must be assigned to both units.',
@@ -622,8 +621,12 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
             count: 2,
         }],
         minUnits: 3,
-        rulesRef: [{ book: Rulebook.CO, page: 63 }],
-        requirements: () => 'Same as Battle Lance.',
+        rulesRef: [{ book: Rulebook.CO, page: 63 }, { book: Rulebook.FMK, page: 87}],
+        requirements: () => {
+            const heavyOrAssault = isAS ? 'Size 3+' : 'heavy or assault';
+            const heavy = isAS ? 'Size 3' : 'heavy';
+            return `Minimum 3 units. 50% must be ${heavyOrAssault}. At least 3 Brawler, Sniper, or Skirmisher roles. Vehicle formations require 2 matched pairs of ${heavy} units.`;
+        },
         validator: (units) => {
             const heavyUnits = units.filter(u =>
                 isAS ? asGetSize(u.getUnit()) >= 3 : cbtIsHeavyOrLarger(u.getUnit()));
@@ -697,7 +700,7 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         ],
         exclusiveFaction: 'Draconis Combine',
         minUnits: 3,
-        rulesRef: [{ book: Rulebook.CO, page: 63 }],
+        rulesRef: [{ book: Rulebook.CO, page: 63 }, { book: Rulebook.FMK, page: 89}],
         requirements: () => {
             const weight = isAS ? 'Size' : 'weight';
             return `Minimum 3 units. Draconis Combine only. All units must share the same ${weight} class and chassis.`;
@@ -777,7 +780,6 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
     //
     {
         id: 'anti-air-lance',
-        parent: 'fire-lance',
         name: 'Anti-Air',
         description: 'Air defense specialists',
         effectDescription: 'At the beginning of each turn, up to two units in this formation may receive the Anti-Aircraft Specialist Special Command Ability. This will affect the weapon attacks made by the designated units during that turn.',
@@ -794,22 +796,25 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
             const weapons = isAS
                 ? 'FLK, AC, or ART specials'
                 : 'an LBX autocannon, standard autocannon, artillery weapon, or Anti-Aircraft Targeting quirk';
-            return `Minimum 3 units. Must meet Fire Lance requirements. At least 2 units with ${weapons}.`;
+            return `Minimum 3 units. 75% must have the Missile Boat or Sniper role. At least 2 units with ${weapons}.`;
         },
         validator: (units) => {
-            if (isAS) {
-                const qualifyingUnits = units.filter(u =>
-                    asHasSpecial(u.getUnit(), 'FLK') ||
-                    asHasSpecial(u.getUnit(), 'AC') ||
-                    asHasSpecial(u.getUnit(), 'ART'));
-                return qualifyingUnits.length >= 2;
-            } else {
-                const qualifyingUnits = units.filter(u =>
-                    cbtHasAutocannon(u.getUnit()) ||
-                    cbtHasArtillery(u.getUnit()) ||
-                    u.getUnit().quirks.includes('Anti-Aircraft Targeting'));
-                return qualifyingUnits.length >= 2;
-            }
+            const count = units.filter(u => u.getUnit().role === 'Missile Boat' || u.getUnit().role === 'Sniper');
+            if (count.length >= Math.ceil(units.length * 0.75)) {
+                if (isAS) {
+                    const qualifyingUnits = units.filter(u =>
+                        asHasSpecial(u.getUnit(), 'FLK') ||
+                        asHasSpecial(u.getUnit(), 'AC') ||
+                        asHasSpecial(u.getUnit(), 'ART'));
+                    return qualifyingUnits.length >= 2;
+                } else {
+                    const qualifyingUnits = units.filter(u =>
+                        cbtHasAutocannon(u.getUnit()) ||
+                        cbtHasArtillery(u.getUnit()) ||
+                        u.getUnit().quirks.includes('Anti-Aircraft Targeting'));
+                    return qualifyingUnits.length >= 2;
+                }
+            } else return false;
         },
     },
 
@@ -1341,7 +1346,7 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         effectDescription: 'Swarm: When any unit in this formation is targeted by an enemy attack, that unit\'s player may switch the target to any other unit in this formation that is still a legal target (within line of sight) and at the same range or less from the attacker. This ability can only be used by units which spent Running, Jumping, or Flank movement points that turn.',
         minUnits: 5,
         maxUnits: 10,
-        rulesRef: [{ book: Rulebook.CO, page: 67 }],
+        rulesRef: [{ book: Rulebook.CO, page: 66 }, { book: Rulebook.FMK, page: 87 }],
         requirements: () => {
             const light = isAS ? 'Size 1' : 'light';
             const mediumRange = isAS ? 'have medium-range damage < 2' : 'deal less than 11 damage at 9 hexes';
@@ -1374,7 +1379,7 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         }],
         idealRole: 'Skirmisher',
         minUnits: 3,
-        rulesRef: [{ book: Rulebook.CO, page: 67 }],
+        rulesRef: [{ book: Rulebook.CO, page: 66 }],
         requirements: () => {
             const assault = isAS ? 'Size 4+' : 'assault';
             return `Minimum 3 units. No ${assault} units.`;
@@ -1432,130 +1437,7 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         },
     },
 
-    // ─── CLAN-EXCLUSIVE FORMATIONS ──────────────────────────────────────────────
-    //
-    // Phalanx Star
-    // Bonus: Float Like a Butterfly SPA shared pool. Max 6 rerolls per track. Only one reroll per attack or critical hit roll.
-    //
-    {
-        id: 'phalanx-star',
-        name: 'Phalanx',
-        description: 'Second-Line combined arms defensive formation.',
-        effectDescription: 'The formation receives a Float Like a Butterfly SPA. Useable by any unit in the formation. (max 6 rerolls per scenario).',
-        effectGroups: [{
-            abilityIds: ['float_like_a_butterfly'],
-            selection: 'all',
-            distribution: 'shared-pool',
-        }],
-        minUnits: 3,
-        rulesRef: [{ book: Rulebook.BOT, page: 27 }],
-        requirements: () => 'Clan only. Minimum 2 combat vehicles or BattleMeks. Remainder must be Elementals, combat vehicles, or BattleMeks. Must be at least two different unit types.',
-        validator: (units) => {
-            if (!isClanForce(units)) return false;
-            if (isAS) {
-                const BM = units.filter(u => u.getUnit().as?.TP === 'BM').length;
-                const BA = units.filter(u => u.getUnit().as?.TP === 'BA').length;
-                const CV = units.filter(u => u.getUnit().as?.TP === 'CV').length;
-                if (units.length > BM + BA + CV) return false;
-                return (BM >= 2 && (BA > 0 || CV > 0)) || (CV >= 2 && (BM > 0 || BA > 0)); 
-            } else {
-                const BM = units.filter(u => u.getUnit().type === 'Mek').length;
-                const BA = units.filter(u => u.getUnit().subtype === 'Battle Armor').length;
-                const CV = units.filter(u => u.getUnit().type === 'Tank' || u.getUnit().type === 'VTOL' || u.getUnit().type === 'Naval').length;
-                if (units.length > BM + BA + CV) return false;
-                return (BM >= 2 && (BA > 0 || CV > 0)) || (CV >= 2 && (BM > 0 || BA > 0)); 
-            }
-        },
-    },
-
-    //
-    // Rogue Star
-    // Bonus: At the beginning of each turn, up to 2 units get Combat Intuition SPA.
-    //
-
-    {
-        id: 'rogue-star',
-        name: 'Rogue',
-        description: 'Swift strike formation.',
-        effectDescription: 'At the beginning of each turn, up to two units in this formation may receive the Combat Intuition SPA.',
-        effectGroups: [{
-            abilityIds: ['combat_intuition'],
-            selection: 'all',
-            distribution: 'fixed',
-            count: 2,
-            perTurn: true,
-        }],
-        minUnits: 3,
-        rulesRef: [{ book: Rulebook.BOT, page: 27 }],
-        requirements: () => 'Clan only. At least two units in the Formation must be the same model (including the same OmniMek configuration)',
-        validator: (units) => {
-            if (!isClanForce(units)) return false;
-            const seen = new Set<string>();
-            const hasPair = units.some(unit => {
-                const name = unit.getUnit().name;
-                if (seen.has(name)) return true;
-                seen.add(name);
-                return false;
-            });
-            return hasPair;
-        },
-    },
-
-    //
-    // Strategic Command Star
-    // Bonus: Two non-commander units get one free SPA each (Antagonizer,
-    //   Blood Stalker, Combat Intuition, Eagle's Eyes, Marksman, Multi-Tasker).
-    //   Commander gets Tactical Genius.
-
-    {
-        id: 'strategic-command-star',
-        name: 'Strategic Command',
-        description: 'Combined arms command star.',
-        effectDescription: 'Clan only. Prior to the beginning of play, two of the non-commander units in this formation receive one of the following Special Pilot Abilities for free (each unit may receive a different SPA): Antagonizer, Combat Intuition, Blood Stalker, Eagle\'s Eyes, Marksman, or Multi-Tasker. In addition, the commander\'s unit receives the Tactical Genius SPA. If the commander already has the Tactical Genius SPA, instead add a +1 modifier to the force\'s Initiative roll results, including any rerolls made as a result of the Tactical Genius SPA. Aerospace units cannot be designated force commander.',
-        effectGroups: [
-            {
-                abilityIds: ['antagonizer', 'blood_stalker', 'combat_intuition', 'eagles_eyes', 'marksman', 'multi_tasker'],
-                selection: 'choose-each',
-                distribution: 'fixed',
-                count: 2,
-                excludeCommander: true,
-            },
-            {
-                abilityIds: ['tactical_genius'],
-                selection: 'all',
-                distribution: 'commander',
-            },
-        ],
-        minUnits: 3,
-        rulesRef: [{ book: Rulebook.BOT, page: 27 }],
-        requirements: () => {
-            const gunnery = isAS ? '' : 'Gunnery ';
-            const heavyOrAssault = isAS ? 'Size 3+, and no size 1' : 'heavy or assault, and no lights';
-            return `Minimum 3 units. All must have ${gunnery}Skill 3 or lower. Must have 1 Aerospace Point. Others must be Mek or Battle Armor. If Mek, at least 2 units ${heavyOrAssault}.`;
-        },
-        validator: (units) => {
-            if (!isClanForce(units)) return false;
-            const skillCheck = units.every(u =>
-            (isAS ? (u as ASForceUnit).pilotSkill() : (u as CBTForceUnit).gunnerySkill()) <= 3);
-            if (!skillCheck) return false;
-            const hasAF = units.filter(u =>
-                (isAS ? u.getUnit().as?.TP === 'AF' : u.getUnit().type === 'Aero')).length;
-            if (hasAF !== 2) return false;
-            const hasBM = units.filter(u =>
-                (isAS ? u.getUnit().as?.TP === 'BM' : u.getUnit().type === 'Mek')).length;
-                if (hasBM > 0) { 
-                    const heavyMeks = units.filter(u => isAS ? (u.getUnit().as?.TP === 'BM' && asGetSize(u.getUnit()) >= 3) : (u.getUnit().type === 'Mek' && cbtIsHeavyOrLarger(u.getUnit()))).length;
-                    const lightMeks = units.some(u => isAS ? (u.getUnit().as?.TP === 'BM' && asGetSize(u.getUnit()) === 1) : (u.getUnit().type === 'Mek' && cbtIsLightWeight(u.getUnit())));
-                    if (heavyMeks < 2 || lightMeks) return false;
-                }
-            const hasBA = units.filter(u =>
-                (isAS ? u.getUnit().as?.TP === 'BA' : u.getUnit().subtype === 'Battle Armor')).length;
-            return hasAF === 2 && (hasBM >= 2 || hasBA >= 1);
-        },
-    },
-
     // ─── Aerospace Formations ────────────────────────────────────────────
-
     //
     // INTERCEPTOR SQUADRON
     // Bonus: Units with Thrust ≤ 9 get Speed Demon. Up to 2 get Range Master (Long).
@@ -1740,6 +1622,128 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
                 if (!units.every(u => u.getUnit().type === 'Aero')) return false;
             }
             return units.filter(u => u.getUnit().role?.includes('Transport')).length >= Math.ceil(units.length * 0.5);
+        },
+    },
+
+    // ─── CLAN-EXCLUSIVE FORMATIONS ──────────────────────────────────────────────
+    //
+    // Phalanx Star
+    // Bonus: Float Like a Butterfly SPA shared pool. Max 6 rerolls per track. Only one reroll per attack or critical hit roll.
+    //
+    {
+        id: 'phalanx-star',
+        name: 'Phalanx',
+        description: 'Second-Line combined arms defensive formation.',
+        effectDescription: 'The formation receives a Float Like a Butterfly SPA. Useable by any unit in the formation. (max 6 rerolls per scenario).',
+        effectGroups: [{
+            abilityIds: ['float_like_a_butterfly'],
+            selection: 'all',
+            distribution: 'shared-pool',
+        }],
+        minUnits: 3,
+        rulesRef: [{ book: Rulebook.BOT, page: 27 }],
+        requirements: () => 'Clan only. Minimum 2 combat vehicles or BattleMeks. Remainder must be Elementals, combat vehicles, or BattleMeks. Must be at least two different unit types.',
+        validator: (units) => {
+            if (!isClanForce(units)) return false;
+            if (isAS) {
+                const BM = units.filter(u => u.getUnit().as?.TP === 'BM').length;
+                const BA = units.filter(u => u.getUnit().as?.TP === 'BA').length;
+                const CV = units.filter(u => u.getUnit().as?.TP === 'CV').length;
+                if (units.length > BM + BA + CV) return false;
+                return (BM >= 2 && (BA > 0 || CV > 0)) || (CV >= 2 && (BM > 0 || BA > 0)); 
+            } else {
+                const BM = units.filter(u => u.getUnit().type === 'Mek').length;
+                const BA = units.filter(u => u.getUnit().subtype === 'Battle Armor').length;
+                const CV = units.filter(u => u.getUnit().type === 'Tank' || u.getUnit().type === 'VTOL' || u.getUnit().type === 'Naval').length;
+                if (units.length > BM + BA + CV) return false;
+                return (BM >= 2 && (BA > 0 || CV > 0)) || (CV >= 2 && (BM > 0 || BA > 0)); 
+            }
+        },
+    },
+
+    //
+    // Rogue Star
+    // Bonus: At the beginning of each turn, up to 2 units get Combat Intuition SPA.
+    //
+
+    {
+        id: 'rogue-star',
+        name: 'Rogue',
+        description: 'Swift strike formation.',
+        effectDescription: 'At the beginning of each turn, up to two units in this formation may receive the Combat Intuition SPA.',
+        effectGroups: [{
+            abilityIds: ['combat_intuition'],
+            selection: 'all',
+            distribution: 'fixed',
+            count: 2,
+            perTurn: true,
+        }],
+        minUnits: 3,
+        rulesRef: [{ book: Rulebook.BOT, page: 27 }],
+        requirements: () => 'Clan only. At least two units in the Formation must be the same model (including the same OmniMek configuration)',
+        validator: (units) => {
+            if (!isClanForce(units)) return false;
+            const seen = new Set<string>();
+            const hasPair = units.some(unit => {
+                const name = unit.getUnit().name;
+                if (seen.has(name)) return true;
+                seen.add(name);
+                return false;
+            });
+            return hasPair;
+        },
+    },
+
+    //
+    // Strategic Command Star
+    // Bonus: Two non-commander units get one free SPA each (Antagonizer,
+    //   Blood Stalker, Combat Intuition, Eagle's Eyes, Marksman, Multi-Tasker).
+    //   Commander gets Tactical Genius.
+
+    {
+        id: 'strategic-command-star',
+        name: 'Strategic Command',
+        description: 'Combined arms command star.',
+        effectDescription: 'Clan only. Prior to the beginning of play, two of the non-commander units in this formation receive one of the following Special Pilot Abilities for free (each unit may receive a different SPA): Antagonizer, Combat Intuition, Blood Stalker, Eagle\'s Eyes, Marksman, or Multi-Tasker. In addition, the commander\'s unit receives the Tactical Genius SPA. If the commander already has the Tactical Genius SPA, instead add a +1 modifier to the force\'s Initiative roll results, including any rerolls made as a result of the Tactical Genius SPA. Aerospace units cannot be designated force commander.',
+        effectGroups: [
+            {
+                abilityIds: ['antagonizer', 'blood_stalker', 'combat_intuition', 'eagles_eyes', 'marksman', 'multi_tasker'],
+                selection: 'choose-each',
+                distribution: 'fixed',
+                count: 2,
+                excludeCommander: true,
+            },
+            {
+                abilityIds: ['tactical_genius'],
+                selection: 'all',
+                distribution: 'commander',
+            },
+        ],
+        minUnits: 3,
+        rulesRef: [{ book: Rulebook.BOT, page: 27 }],
+        requirements: () => {
+            const gunnery = isAS ? '' : 'Gunnery ';
+            const heavyOrAssault = isAS ? 'Size 3+, and no size 1' : 'heavy or assault, and no lights';
+            return `Minimum 3 units. All must have ${gunnery}Skill 3 or lower. Must have 1 Aerospace Point. Others must be Mek or Battle Armor. If Mek, at least 2 units ${heavyOrAssault}.`;
+        },
+        validator: (units) => {
+            if (!isClanForce(units)) return false;
+            const skillCheck = units.every(u =>
+            (isAS ? (u as ASForceUnit).pilotSkill() : (u as CBTForceUnit).gunnerySkill()) <= 3);
+            if (!skillCheck) return false;
+            const hasAF = units.filter(u =>
+                (isAS ? u.getUnit().as?.TP === 'AF' : u.getUnit().type === 'Aero')).length;
+            if (hasAF !== 2) return false;
+            const hasBM = units.filter(u =>
+                (isAS ? u.getUnit().as?.TP === 'BM' : u.getUnit().type === 'Mek')).length;
+                if (hasBM > 0) { 
+                    const heavyMeks = units.filter(u => isAS ? (u.getUnit().as?.TP === 'BM' && asGetSize(u.getUnit()) >= 3) : (u.getUnit().type === 'Mek' && cbtIsHeavyOrLarger(u.getUnit()))).length;
+                    const lightMeks = units.some(u => isAS ? (u.getUnit().as?.TP === 'BM' && asGetSize(u.getUnit()) === 1) : (u.getUnit().type === 'Mek' && cbtIsLightWeight(u.getUnit())));
+                    if (heavyMeks < 2 || lightMeks) return false;
+                }
+            const hasBA = units.filter(u =>
+                (isAS ? u.getUnit().as?.TP === 'BA' : u.getUnit().subtype === 'Battle Armor')).length;
+            return hasAF === 2 && (hasBM >= 2 || hasBA >= 1);
         },
     },
 ];

--- a/src/app/utils/formation-definitions.ts
+++ b/src/app/utils/formation-definitions.ts
@@ -38,6 +38,7 @@ import { GameSystem, Rulebook } from '../models/common.model';
 import { isClan } from './org/org-registry.util';
 import { CBTForceUnit } from '../models/cbt-force-unit.model';
 import { ASForceUnit } from '../models/as-force-unit.model';
+import { OptionsService } from '../services/options.service';
 
 /*
  * Author: Drake
@@ -51,7 +52,13 @@ import { ASForceUnit } from '../models/as-force-unit.model';
 
 // ── AS helper functions ──────────────────────────────────────────────────────
 
+const isAS = GameSystem.ALPHA_STRIKE;
 const AEROSPACE_MODES = new Set(['a', 'p', 'k']);
+
+function isHex(value: number): string {
+    const useHex = OptionsService.get()?.options()?.ASUseHex ?? false;
+    return useHex ? `${Math.round(value / 2)}⬢` : `${value}″`;
+}
 
 function asGetSize(unit: Unit): number {
     return unit.as?.SZ ?? 0;
@@ -235,14 +242,11 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         effectDescription: 'Distracting Swarm: units in this formation swarming an enemy unit cause a +1 To-Hit modifier to any weapon attacks made by the enemy unit.',
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 61 }],
-        requirements: (gameSystem) => {
-            const inf = gameSystem === GameSystem.ALPHA_STRIKE
-                ? 'infantry (CI, BA, or PM)'
-                : 'Infantry';
-            return `Minimum 3 units. All units must be ${inf}.`;
+        requirements: () => {
+            const infantry = isAS ? ' (CI, BA, or PM)': '';
+            return `Minimum 3 units. All units must be Infantry${infantry}.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             return units.every(u => isAS ? asIsInfantry(u.getUnit()) : u.getUnit().type === 'Infantry');
         },
     },
@@ -269,18 +273,20 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         idealRole: 'Juggernaut',
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 61 }, { book: Rulebook.ASCE, page: 118 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. At least 3 units Size 3+. No Size 1 units. All armor ≥ 5. 75% must have medium-range damage ≥ 3. At least 1 Juggernaut or 2 Snipers.';
-            }
-            return 'Minimum 3 units. At least 3 heavy or assault. No light units. All armor ≥ 135 points. 75% must deal 25+ damage at 7 hexes. At least 1 Juggernaut or 2 Snipers.';
+        requirements: () => {
+            const heavyOrAssault = isAS ? 'Size 3+' : 'heavy or assault';
+            const light = isAS ? 'Size 1' : 'light';
+            const armor = isAS ? '5' : '135 points';
+            const mediumRange = isAS ? 'have medium-range damage ≥ 3' : 'deal 25+ damage at 7 hexes';
+            return `Minimum 3 units. At least 3 ${heavyOrAssault}. No ${light} units. All armor ≥ ${armor}. 75% must ${mediumRange}. At least 1 Juggernaut or 2 Snipers.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
-            const heavyUnits = units.filter(u =>
-                isAS ? asGetSize(u.getUnit()) >= 3 : cbtIsHeavyOrLarger(u.getUnit()));
-            const hasLight = units.some(u =>
-                isAS ? asGetSize(u.getUnit()) === 1 : cbtIsLightWeight(u.getUnit()));
+        validator: (units) => {
+            const heavyUnits = units.filter(u => isAS
+                ? asGetSize(u.getUnit()) >= 3
+                : cbtIsHeavyOrLarger(u.getUnit()));
+            const hasLight = units.some(u => isAS
+                ? asGetSize(u.getUnit()) === 1
+                : cbtIsLightWeight(u.getUnit()));
             if (heavyUnits.length < 3 || hasLight) return false;
             if (isAS) {
                 const hasEnoughArmor = units.every(u => (u.getUnit().as?.Arm ?? 0) >= 5);
@@ -318,14 +324,13 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         idealRole: 'Juggernaut',
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 62 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. Free Worlds League only. All Size 2+. All armor ≥ 4. 50% must have AC, FLK, LRM, or SRM specials.';
-            }
-            return 'Minimum 3 units. Free Worlds League only. All medium or heavier. All armor ≥ 105 points. 50% must have autocannons, LRMs, or SRMs.';
+        requirements: () => {
+            const mediumOrHeavier = isAS ? 'Size 2+' : 'medium or heavier';
+            const equipment = isAS ? '4. 50% must have AC, FLK, LRM, or SRM specials' : '105 points. 50% must have autocannons, LRMs, or SRMs';
+            return `Minimum 3 units. Free Worlds League only. All ${mediumOrHeavier}. All armor ≥ ${equipment}.`;
         },
-        validator: (units: ForceUnit[], gameSystem: GameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
+        validator: (units) => {
+            if (isAS) {
             const allMediumOrLarger = units.every(u => asGetSize(u.getUnit()) >= 2);
             const hasEnoughArmor = units.every(u => (u.getUnit().as?.Arm ?? 0) >= 4);
             const hasWeapons = units.filter(u =>
@@ -337,8 +342,10 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
             } else {
                 const allMediumOrLarger = units.every(u => cbtIsMediumOrLarger(u.getUnit()));
                 const hasEnoughArmor = units.every(u => u.getUnit().armor >= 105);
-                const hasWeapons = units.filter(u => cbtHasAutocannon(u.getUnit()) ||
-                    cbtHasLRM(u.getUnit()) || cbtHasSRM(u.getUnit()));
+                const hasWeapons = units.filter(u =>
+                    cbtHasAutocannon(u.getUnit()) ||
+                    cbtHasLRM(u.getUnit()) ||
+                    cbtHasSRM(u.getUnit()));
                 return allMediumOrLarger && hasEnoughArmor && hasWeapons.length >= Math.ceil(units.length * 0.5);
             }
         },
@@ -364,14 +371,12 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         }],
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 62 }, { book: Rulebook.ASCE, page: 118 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. Must meet Assault Lance requirements. All units must have Move 10"+ or any jump capability.';
-            }
-            return 'Minimum 3 units. Must meet Assault Lance requirements. All units must have walk ≥ 5 or jump > 0.';
+        requirements: () => {
+            const move = isAS ? `${isHex(10)} or any jump capability` : 'walk ≥ 5 or jump > 0';
+            return `Must meet Assault Lance requirements. All units must have ${move}.`;
         },
-        validator: (units: ForceUnit[], gameSystem: GameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
+        validator: (units) => {
+            if (isAS) {
                 return units.every(u => {
                     const groundMove = asGetMaxGroundMove(u.getUnit());
                     const jumpMove = asGetJumpMove(u.getUnit());
@@ -404,8 +409,7 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         rulesRef: [{ book: Rulebook.CO, page: 62 }],
         requirements: () => 'Minimum 3 units. At least 50% must have the Ambusher or Juggernaut role.',
         validator: (units) => {
-            const count = units.filter(u =>
-                u.getUnit().role === 'Ambusher' || u.getUnit().role === 'Juggernaut');
+            const count = units.filter(u => u.getUnit().role === 'Ambusher' || u.getUnit().role === 'Juggernaut');
             return count.length >= Math.ceil(units.length * 0.5);
         },
     },
@@ -429,14 +433,15 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         idealRole: 'Brawler',
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 62 }, { book: Rulebook.ASCE, page: 117 }],
-        requirements: (gameSystem) => {
-            const heavy = gameSystem === GameSystem.ALPHA_STRIKE ? 'Size 3+' : 'heavy or assault';
-            return `Minimum 3 units. 50% must be ${heavy}. At least 3 Brawler, Sniper, or Skirmisher roles. Vehicle formations require 2 matched pairs of heavy units.`;
+        requirements: () => {
+            const heavyOrAssault = isAS ? 'Size 3+' : 'heavy or assault';
+            const heavy = isAS ? 'Size 3' : 'heavy';
+            return `Minimum 3 units. 50% must be ${heavyOrAssault}. At least 3 Brawler, Sniper, or Skirmisher roles. Vehicle formations require 2 matched pairs of ${heavy} units.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
-            const heavyUnits = units.filter(u =>
-                isAS ? asGetSize(u.getUnit()) >= 3 : cbtIsHeavyOrLarger(u.getUnit()));
+        validator: (units) => {
+            const heavyUnits = units.filter(u => isAS
+                ? asGetSize(u.getUnit()) >= 3
+                : cbtIsHeavyOrLarger(u.getUnit()));
             if (isAS ? asIsOnlyCombatVehicles(units) : cbtIsOnlyCombatVehicles(units)) {
                 if (countMatchedPairs(heavyUnits) < 2) return false;
             }
@@ -461,14 +466,12 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         }],
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 62 }, { book: Rulebook.ASCE, page: 117 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. 75% must be Size 1. No Size 4+ units. At least 1 Scout. Vehicle formations require 2 matched pairs of light units.';
-            }
-            return 'Minimum 3 units. 75% must be light. No assault units. At least 1 Scout. Vehicle formations require 2 matched pairs of light units.';
+        requirements: () => {
+            const lightNoAssault = isAS ? 'Size 1. No Size 4+' : 'light. No assault';
+            const light = isAS ? 'Size 1' : 'light';
+            return `Minimum 3 units. 75% must be ${lightNoAssault} units. At least 1 Scout. Vehicle formations require 2 matched pairs of ${light} units.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const lightUnits = units.filter(u => isAS
                 ? asGetSize(u.getUnit()) === 1
                 : cbtIsLightWeight(u.getUnit()));
@@ -498,14 +501,12 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         }],
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 62 }, { book: Rulebook.ASCE, page: 117 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. 50% must be Size 2. No Size 4+ units. Vehicle formations require 2 matched pairs of medium units.';
-            }
-            return 'Minimum 3 units. 50% must be medium. No assault units. Vehicle formations require 2 matched pairs of medium units.';
+        requirements: () => {
+            const mediumNoAssault = isAS ? 'Size 2. No Size 4+' : 'medium. No assault';
+            const medium = isAS ? 'Size 2' : 'medium';
+            return `Minimum 3 units. 50% must be ${mediumNoAssault} units. Vehicle formations require 2 matched pairs of ${medium} units.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const mediumUnits = units.filter(u => isAS
                 ? asGetSize(u.getUnit()) === 2
                 : cbtIsMediumWeight(u.getUnit()));
@@ -534,14 +535,12 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         }],
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 63 }, { book: Rulebook.ASCE, page: 117 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. 50% must be Size 3+. No Size 1 units. Vehicle formations require 2 matched pairs of heavy units.';
-            }
-            return 'Minimum 3 units. 50% must be heavy or assault. No light units. Vehicle formations require 2 matched pairs of heavy units.';
+        requirements: () => {
+            const heavyNoLight = isAS ? 'Size 3+. No Size 1' : 'heavy or assault. No light';
+            const heavy = isAS ? 'Size 3' : 'heavy';
+            return `Minimum 3 units. 50% must be ${heavyNoLight} units. Vehicle formations require 2 matched pairs of ${heavy} units.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const heavyUnits = units.filter(u =>
                 isAS ? asGetSize(u.getUnit()) >= 3 : cbtIsHeavyOrLarger(u.getUnit()));
             const hasLight = units.some(u => isAS
@@ -573,14 +572,14 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         exclusiveFaction: 'Federated Suns',
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 63 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. Federated Suns only. 75% must be Size 2-3. 50% must have AC or FLK special. All units Move 8"+.';
-            }
-            return 'Minimum 3 units. Federated Suns only. 75% must be medium or heavy. 50% must have autocannons (including LB-X, Ultra, or Rotary). All units walk ≥ 4.';
+        requirements: () => {
+            const mediumOrHeavy = isAS ? 'Size 2-3' : 'medium or heavy';
+            const equipment = isAS
+                ? `AC or FLK special. All units Move ${isHex(8)}+`
+                : 'autocannons (including LB-X, Ultra, or Rotary). All units walk ≥ 4';
+            return `Minimum 3 units. Federated Suns only. 75% must be ${mediumOrHeavy}. 50% must have ${equipment}.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             if (isAS) {
                 const mediumOrHeavy = units.filter(u => {
                     const sz = asGetSize(u.getUnit());
@@ -612,6 +611,7 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
     {
         id: 'berserker-lance',
         name: 'Berserker/Close Combat',
+        parent: 'battle-lance',
         nameAliases: ['Berserker', 'Close Combat'],
         description: 'Close combat specialists for physical attacks',
         effectDescription: 'Two units in this formation receive the Swordsman or Zweihander SPA. The same ability must be assigned to both units.',
@@ -623,12 +623,8 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         }],
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 63 }],
-        requirements: (gameSystem) => {
-            const heavy = gameSystem === GameSystem.ALPHA_STRIKE ? 'Size 3+' : 'heavy or assault';
-            return `Minimum 3 units. Same as Battle Lance: 50% must be ${heavy}. At least 3 Brawler, Sniper, or Skirmisher roles. Vehicle formations require 2 matched pairs.`;
-        },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        requirements: () => 'Same as Battle Lance.',
+        validator: (units) => {
             const heavyUnits = units.filter(u =>
                 isAS ? asGetSize(u.getUnit()) >= 3 : cbtIsHeavyOrLarger(u.getUnit()));
             if (isAS ? asIsOnlyCombatVehicles(units) : cbtIsOnlyCombatVehicles(units)) {
@@ -702,12 +698,11 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         exclusiveFaction: 'Draconis Combine',
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 63 }],
-        requirements: (gameSystem) => {
-            const tier = gameSystem === GameSystem.ALPHA_STRIKE ? 'Size class' : 'weight class';
-            return `Minimum 3 units. Draconis Combine only. All units must share the same ${tier} and chassis.`;
+        requirements: () => {
+            const weight = isAS ? 'Size' : 'weight';
+            return `Minimum 3 units. Draconis Combine only. All units must share the same ${weight} class and chassis.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const firstTier = isAS ? asGetSize(units[0].getUnit()) : cbtGetWeightClass(units[0].getUnit());
             const sameTier = units.every(u =>
                 (isAS ? asGetSize(u.getUnit()) : cbtGetWeightClass(u.getUnit())) === firstTier);
@@ -741,8 +736,7 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 63 }, { book: Rulebook.ASCE, page: 120 }],
         requirements: () => 'Minimum 3 units. All must be combat vehicles. At least one matched pair with Sniper, Missile Boat, Skirmisher, or Juggernaut role.',
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             if (!(isAS ? asIsOnlyCombatVehicles(units) : cbtIsOnlyCombatVehicles(units))) return false;
             return findIdenticalPairs(units).some(pair =>
                 pair.every(u =>
@@ -772,8 +766,7 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         rulesRef: [{ book: Rulebook.CO, page: 64 }, { book: Rulebook.ASCE, page: 119 }],
         requirements: () => 'Minimum 3 units. 75% must have the Missile Boat or Sniper role.',
         validator: (units) => {
-            const count = units.filter(u =>
-                u.getUnit().role === 'Missile Boat' || u.getUnit().role === 'Sniper');
+            const count = units.filter(u => u.getUnit().role === 'Missile Boat' || u.getUnit().role === 'Sniper');
             return count.length >= Math.ceil(units.length * 0.75);
         },
     },
@@ -797,14 +790,14 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         }],
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 64 }, { book: Rulebook.ASCE, page: 119 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. Must meet Fire Lance requirements. At least 2 units with FLK, AC, or ART specials.';
-            }
-            return 'Minimum 3 units. Must meet Fire Lance requirements. At least 2 units with an LBX autocannon, standard autocannon, artillery weapon, or Anti-Aircraft Targeting quirk.';
+        requirements: () => {
+            const weapons = isAS
+                ? 'FLK, AC, or ART specials'
+                : 'an LBX autocannon, standard autocannon, artillery weapon, or Anti-Aircraft Targeting quirk';
+            return `Minimum 3 units. Must meet Fire Lance requirements. At least 2 units with ${weapons}.`;
         },
-        validator: (units, gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
+        validator: (units) => {
+            if (isAS) {
                 const qualifyingUnits = units.filter(u =>
                     asHasSpecial(u.getUnit(), 'FLK') ||
                     asHasSpecial(u.getUnit(), 'AC') ||
@@ -838,14 +831,11 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         }],
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 64 }, { book: Rulebook.ASCE, page: 119 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. At least 2 units with the ART special.';
-            }
-            return 'Minimum 3 units. At least 2 units with artillery weapons.';
+        requirements: () => {
+            const artillery = isAS ? 'the ART special' : 'artillery weapons';
+            return `Minimum 3 units. At least 2 units with ${artillery}.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const artilleryCount = units.filter(u => isAS
                 ? asHasSpecial(u.getUnit(), 'ART')
                 : cbtHasArtillery(u.getUnit())).length;
@@ -871,14 +861,12 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         }],
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 64 }, { book: Rulebook.ASCE, page: 119 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. At least 2 Size 3+ units. All units must have long-range damage ≥ 2.';
-            }
-            return 'Minimum 3 units. At least 2 heavy or assault units. All units must deal 10+ damage at 18 hexes.';
+        requirements: () => {
+            const heavyOrAssault = isAS ? 'Size 3+' : 'heavy or assault';
+            const longRange = isAS ? 'long-range damage ≥ 2' : 'deal 10+ damage at 18 hexes';
+            return `Minimum 3 units. At least 2 ${heavyOrAssault} units. All units must have ${longRange}.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const heavyUnits = units.filter(u =>
                 isAS ? asGetSize(u.getUnit()) >= 3 : cbtIsHeavyOrLarger(u.getUnit()));
             const allLongRange = isAS
@@ -906,14 +894,11 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         }],
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 64 }, { book: Rulebook.ASCE, page: 119 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. At least 3 units with the IF (Indirect Fire) special.';
-            }
-            return 'Minimum 3 units. At least 3 units with LRMs or artillery.';
+        requirements: () => {
+            const indirectFire = isAS ? 'the IF (Indirect Fire) special' : 'LRMs or artillery';
+            return `Minimum 3 units. At least 3 units with ${indirectFire}.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const indirectCount = units.filter(u => isAS
                 ? asHasSpecial(u.getUnit(), 'IF')
                 : (cbtHasLRM(u.getUnit()) || cbtHasArtillery(u.getUnit()))).length;
@@ -932,12 +917,11 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         effectDescription: 'Coordinated Fire Support: If a unit in this formation hits a target with at least one of its weapons, other units in this formation making weapon attacks against the same target receive a -1 modifier to their attack rolls. This bonus is cumulative per attacking unit, up to a -3 To-Hit modifier.',
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 64 }, { book: Rulebook.ASCE, page: 119 }],
-        requirements: (gameSystem) => {
-            const noHeavy = gameSystem === GameSystem.ALPHA_STRIKE ? 'No Size 3+ units' : 'No heavy or assault units';
-            return `Minimum 3 units. ${noHeavy}. 50% must have the Missile Boat or Sniper role.`;
+        requirements: () => {
+            const heavyORAssault = isAS ? 'Size 3+' : 'heavy or assault';
+            return `Minimum 3 units. No ${heavyORAssault} units. 50% must have the Missile Boat or Sniper role.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const noHeavy = units.every(u =>
                 (isAS ? asGetSize(u.getUnit()) : cbtGetWeightClass(u.getUnit())) < 3);
             const hasRequiredRoles = units.filter(u =>
@@ -963,14 +947,13 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         idealRole: 'Striker',
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 65 }, { book: Rulebook.ASCE, page: 120 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. All Size ≤ 2. 75% must have Move 12"+. At least 1 unit with medium-range damage > 1.';
-            }
-            return 'Minimum 3 units. All light or medium. 75% must have walk ≥ 6. At least 1 unit dealing 5+ damage at 15 hexes.';
+        requirements: () => {
+            const lightOrMedium = isAS ? 'Size ≤ 2' : 'light or medium';
+            const move = isAS ? `Move ${isHex(12)}+` : 'walk ≥ 6';
+            const mediumRange = isAS ? 'with medium-range damage > 1' : 'deal 5+ damage at 15 hexes';
+            return `Minimum 3 units. All ${lightOrMedium}. 75% must have ${move}. At least 1 unit ${mediumRange}.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const allSmallOrMedium = units.every(u =>
                 isAS ? asGetSize(u.getUnit()) <= 2 : cbtIsLightOrMedium(u.getUnit()));
             const fastUnits = units.filter(u => isAS
@@ -998,14 +981,13 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         }],
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 65 }, { book: Rulebook.ASCE, page: 120 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. No Size 4+ units. 75% must have Move 10"+. All units must have medium-range damage ≥ 2.';
-            }
-            return 'Minimum 3 units. No assault units. 75% must have walk ≥ 6. All units must deal 10+ damage at 9 hexes.';
+        requirements: () => {
+            const assault = isAS ? 'Size 4+' : 'assault';
+            const move = isAS ? `Move ${isHex(10)}+` : 'walk ≥ 6';
+            const mediumRange = isAS ? 'have medium-range damage > 1' : 'deal 5+ damage at 15 hexes';
+            return `Minimum 3 units. No ${assault} units. 75% must have ${move}. All units must ${mediumRange}.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const allNotHuge = units.every(u =>
                 (isAS ? asGetSize(u.getUnit()) : cbtGetWeightClass(u.getUnit())) < 4);
             const fastUnits = units.filter(u => isAS
@@ -1033,14 +1015,13 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         }],
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 65 }, { book: Rulebook.ASCE, page: 120 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. All Size ≤ 2. All units must have Move 10"+. All units must have short-range damage ≥ 2.';
-            }
-            return 'Minimum 3 units. All light or medium. All units must have walk ≥ 5. All units must deal 10+ damage at 6 hexes.';
+        requirements: () => {
+            const lightOrMedium = isAS ? 'Size ≤ 2' : 'light or medium';
+            const move = isAS ? `Move ${isHex(10)}+` : 'walk ≥ 5';
+            const shortRange = isAS ? 'have short-range damage ≥ 2' : 'deal 10+ damage at 6 hexes';
+            return `Minimum 3 units. All ${lightOrMedium}. All units must have ${move}. All units must ${shortRange}.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const allSmallOrMedium = units.every(u =>
                 isAS ? asGetSize(u.getUnit()) <= 2 : cbtIsLightOrMedium(u.getUnit()));
             const allFast = units.every(u => isAS
@@ -1079,12 +1060,11 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         idealRole: 'Scout',
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 65 }, { book: Rulebook.ASCE, page: 119 }],
-        requirements: (gameSystem) => {
-            const fast = gameSystem === GameSystem.ALPHA_STRIKE ? 'Move 10"+' : 'walk ≥ 5';
-            return `Minimum 3 units. All units must have ${fast}. At least 2 Scout or Striker roles.`;
+        requirements: () => {
+            const move = isAS ? `Move ${isHex(10)}+` : 'walk ≥ 5';
+            return `Minimum 3 units. All units must have ${move}. At least 2 Scout or Striker roles.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const allFast = units.every(u => isAS
                 ? asGetAnyGroundOrJumpMove(u.getUnit()) >= 10
                 : u.getUnit().walk >= 5);
@@ -1117,14 +1097,13 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         ],
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 66 }, { book: Rulebook.ASCE, page: 119 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. All Move 8"+. At least 2 with Move 10"+. At least 1 Size 3+ unit. At least 2 Scouts.';
-            }
-            return 'Minimum 3 units. All walk ≥ 4. At least 2 with walk ≥ 5. At least 1 heavy or assault. At least 2 Scouts.';
+        requirements: () => {
+            const allMove = isAS ? `Move ${isHex(8)}+` : 'walk ≥ 4';
+            const someMove = isAS ? `Move ${isHex(10)}+` : 'walk ≥ 5';
+            const heavyOrAssault = isAS ? 'Size 3+' : 'heavy or assault';
+            return `Minimum 3 units. All ${allMove}. At least 2 with ${someMove}. At least 1 ${heavyOrAssault}. At least 2 Scouts.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const allFast = units.every(u => isAS
                 ? asGetAnyGroundOrJumpMove(u.getUnit()) >= 8
                 : u.getUnit().walk >= 4);
@@ -1160,14 +1139,12 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         ],
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 66 }, { book: Rulebook.ASCE, page: 119 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. All Size 1. All Move 12"+. All must have the Scout role.';
-            }
-            return 'Minimum 3 units. All light. All walk ≥ 6. All must have the Scout role.';
+        requirements: () => {
+            const light = isAS ? 'Size 1' : 'light';
+            const move = isAS ? `Move ${isHex(12)}+` : 'walk ≥ 6';
+            return `Minimum 3 units. All ${light}. All ${move}. All must have the Scout role.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const allLight = units.every(u =>
                 isAS ? asGetSize(u.getUnit()) === 1 : cbtIsLightWeight(u.getUnit()));
             const allVeryFast = units.every(u => isAS
@@ -1195,12 +1172,11 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         }],
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 65 }],
-        requirements: (gameSystem) => {
-            const assault = gameSystem === GameSystem.ALPHA_STRIKE ? 'Size 4+' : 'assault';
+        requirements: () => {
+            const assault = isAS ? 'Size 4+' : 'assault';
             return `Minimum 3 units. At most 1 ${assault} unit. At least 1 Scout or Striker. At least 1 Sniper or Missile Boat.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const hasScoutOrStriker = units.some(u =>
                 u.getUnit().role === 'Scout' || u.getUnit().role === 'Striker');
             const hasSniperOrMissileBoat = units.some(u =>
@@ -1230,14 +1206,12 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         idealRole: 'Striker',
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 66 }, { book: Rulebook.ASCE, page: 118 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. All Move 10"+ or Jump 8"+. No Size 4+ units. 50% must have Striker or Skirmisher role.';
-            }
-            return 'Minimum 3 units. All walk ≥ 5 or jump ≥ 4. No assault units. 50% must have Striker or Skirmisher role.';
+        requirements: () => {
+            const move = isAS ? `Move ${isHex(10)}+ or Jump ${isHex(8)}+` : 'walk ≥ 5 or jump ≥ 4';
+            const assault = isAS ? 'Size 4+' : 'assault';
+            return `Minimum 3 units. All ${move}. No ${assault} units. 50% must have Striker or Skirmisher role.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const allFast = units.every(u => isAS
                 ? (asGetMaxGroundMove(u.getUnit()) >= 10 || asGetJumpMove(u.getUnit()) >= 8)
                 : (u.getUnit().walk >= 5 || u.getUnit().jump >= 4));
@@ -1269,12 +1243,11 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         idealRole: 'Striker',
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 66 }],
-        requirements: (gameSystem) => {
-            const fast = gameSystem === GameSystem.ALPHA_STRIKE ? 'Move 10"+' : 'walk ≥ 5';
-            return `Minimum 3 units. Free Worlds League only. All units must have ${fast}.`;
+        requirements: () => {
+            const move = isAS ? `Move ${isHex(10)}+` : 'walk ≥ 5';
+            return `Minimum 3 units. Free Worlds League only. All units must have ${move}.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             return units.every(u => isAS
                 ? asGetAnyGroundOrJumpMove(u.getUnit()) >= 10
                 : u.getUnit().walk >= 5);
@@ -1296,15 +1269,14 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
             distribution: 'percent-75',
         }],
         minUnits: 3,
-        rulesRef: [{ book: Rulebook.CO, page: 67 }, { book: Rulebook.ASCE, page: 118 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. All Move 10"+. No Size 3+ units. At least 2 with long-range damage. At least 2 Striker or Skirmisher roles.';
-            }
-            return 'Minimum 3 units. All walk ≥ 5. No heavy or assault units. At least 2 with long-range capability. At least 2 Striker or Skirmisher roles.';
+        rulesRef: [{ book: Rulebook.CO, page: 66 }, { book: Rulebook.ASCE, page: 118 }],
+        requirements: () => {
+            const move = isAS ? `Move ${isHex(10)}+` : 'walk ≥ 5';
+            const noHeavyOrAssault = isAS ? 'Size 3+' : 'heavy or assault';
+            const longRange = isAS ? 'with long-range damage > 0' : 'deal 5+ damage at 18 hexes';
+            return `Minimum 3 units. All ${move}. No ${noHeavyOrAssault} units. At least 2 ${longRange}. At least 2 Striker or Skirmisher roles.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const allFast = units.every(u => isAS
                 ? asGetAnyGroundOrJumpMove(u.getUnit()) >= 10
                 : u.getUnit().walk >= 5);
@@ -1335,14 +1307,13 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         }],
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 66 }, { book: Rulebook.ASCE, page: 118 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. All Move 8"+. At least 3 Size 3+. No Size 1 units. At least 1 with long-range damage > 1. At least 2 Striker or Skirmisher roles.';
-            }
-            return 'Minimum 3 units. All walk ≥ 4. At least 3 heavy or assault. No light units. At least 1 with long-range capability. At least 2 Striker or Skirmisher roles.';
+        requirements: () => {
+            const move = isAS ? `Move ${isHex(8)}+` : 'walk ≥ 4';
+            const heavyOrAssault = isAS ? 'Size 3+. No Size 1' : 'heavy or assault. No light';
+            const longRange = isAS ? 'with long-range damage > 1' : 'deals 5+ damage at 18 hexes';
+            return `Minimum 3 units. All ${move}. At least 3 ${heavyOrAssault} units. At least 1 ${longRange}. At least 2 Striker or Skirmisher roles.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const allFast = units.every(u => isAS
                 ? asGetAnyGroundOrJumpMove(u.getUnit()) >= 8
                 : u.getUnit().walk >= 4);
@@ -1371,15 +1342,13 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         minUnits: 5,
         maxUnits: 10,
         rulesRef: [{ book: Rulebook.CO, page: 67 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return '5-10 units. All Size 1. All must have medium-range damage < 2.';
-            }
-            return '5-10 units. All light. All must deal less than 11 damage at 9 hexes.';
+        requirements: () => {
+            const light = isAS ? 'Size 1' : 'light';
+            const mediumRange = isAS ? 'have medium-range damage < 2' : 'deal less than 11 damage at 9 hexes';
+            return `5-10 units. All ${light}. All must ${mediumRange}.`;
         },
-        validator: (units, gameSystem) => {
+        validator: (units) => {
             if (units.length < 5 || units.length > 10) return false;
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
             const allLight = units.every(u =>
                 isAS ? asGetSize(u.getUnit()) === 1 : cbtIsLightWeight(u.getUnit()));
             const lowDamage = isAS
@@ -1406,12 +1375,11 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         idealRole: 'Skirmisher',
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 67 }],
-        requirements: (gameSystem) => {
-            const noAssault = gameSystem === GameSystem.ALPHA_STRIKE ? 'No Size 4+ units' : 'No assault units';
-            return `Minimum 3 units. ${noAssault}.`;
+        requirements: () => {
+            const assault = isAS ? 'Size 4+' : 'assault';
+            return `Minimum 3 units. No ${assault} units.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             return units.every(u =>
                 (isAS ? asGetSize(u.getUnit()) : cbtGetWeightClass(u.getUnit())) < 4);
         },
@@ -1448,14 +1416,11 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         idealRole: 'Ambusher',
         minUnits: 3,
         rulesRef: [{ book: Rulebook.CO, page: 67 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. 50% must have jump movement or be infantry. 50% must have ground Move ≤ 8".';
-            }
-            return 'Minimum 3 units. 50% must have jump movement or be infantry. 50% must have walk ≤ 4.';
+        requirements: () => {
+            const move = isAS ? `ground Move ≤ ${isHex(8)}+` : 'walk ≤ 4';
+            return `Minimum 3 units. 50% must have jump movement or be infantry. 50% must have ${move}.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             const jumpOrInfantry = units.filter(u => isAS
                 ? (asGetJumpMove(u.getUnit()) > 0 || asIsInfantry(u.getUnit()))
                 : (u.getUnit().jump > 0 || u.getUnit().type === 'Infantry'));
@@ -1485,9 +1450,9 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         minUnits: 3,
         rulesRef: [{ book: Rulebook.BOT, page: 27 }],
         requirements: () => 'Clan only. Minimum 2 combat vehicles or BattleMeks. Remainder must be Elementals, combat vehicles, or BattleMeks. Must be at least two different unit types.',
-        validator: (units, gameSystem) => {
+        validator: (units) => {
             if (!isClanForce(units)) return false;
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
+            if (isAS) {
                 const BM = units.filter(u => u.getUnit().as?.TP === 'BM').length;
                 const BA = units.filter(u => u.getUnit().as?.TP === 'BA').length;
                 const CV = units.filter(u => u.getUnit().as?.TP === 'CV').length;
@@ -1563,15 +1528,13 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         ],
         minUnits: 3,
         rulesRef: [{ book: Rulebook.BOT, page: 27 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 3 units. All must have skill 3 or lower. Must have 1 Aerospace Point. Others must be Mek or Battle Armor. If Mek, at least 2 units Size 3+ and, no Size 1.';
-            }
-                return 'Minimum 3 units. All must have Gunnery Skill 3 or lower. Must have 1 Aerospace Point. Others must be Mek or Battle Armor. If Mek, at least 2 units heavy or assault, and no lights.';
+        requirements: () => {
+            const gunnery = isAS ? '' : 'Gunnery ';
+            const heavyOrAssault = isAS ? 'Size 3+, and no size 1' : 'heavy or assault, and no lights';
+            return `Minimum 3 units. All must have ${gunnery}Skill 3 or lower. Must have 1 Aerospace Point. Others must be Mek or Battle Armor. If Mek, at least 2 units ${heavyOrAssault}.`;
         },
-        validator: (units, gameSystem) => {
+        validator: (units) => {
             if (!isClanForce(units)) return false;
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
             const skillCheck = units.every(u =>
             (isAS ? (u as ASForceUnit).pilotSkill() : (u as CBTForceUnit).gunnerySkill()) <= 3);
             if (!skillCheck) return false;
@@ -1619,8 +1582,7 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         minUnits: 6,
         rulesRef: [{ book: Rulebook.CO, page: 68 }, { book: Rulebook.ASCE, page: 122 }],
         requirements: () => 'Minimum 6 units. All must be aerospace units. More than 50% must have the Interceptor role.',
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             if (!units.every(u => isAS ? asIsAeroUnit(u.getUnit()) : u.getUnit().type === 'Aero')) return false;
             return units.filter(u => u.getUnit().role === 'Interceptor').length > Math.ceil(units.length * 0.5);
         },
@@ -1644,8 +1606,7 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         minUnits: 6,
         rulesRef: [{ book: Rulebook.CO, page: 67 }, { book: Rulebook.ASCE, page: 122 }],
         requirements: () => 'Minimum 6 units. All must be aerospace units. More than 50% must have the Interceptor or Fast Dogfighter role.',
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             if (!units.every(u => isAS ? asIsAeroUnit(u.getUnit()) : u.getUnit().type === 'Aero')) return false;
             const count = units.filter(u =>
                 u.getUnit().role === 'Interceptor' || u.getUnit().role === 'Fast Dogfighter');
@@ -1672,8 +1633,7 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         minUnits: 6,
         rulesRef: [{ book: Rulebook.CO, page: 68 }, { book: Rulebook.ASCE, page: 122 }],
         requirements: () => 'Minimum 6 units. All must be aerospace units. 50% or more must have the Fire Support role. At least 1 Dogfighter.',
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             if (!units.every(u => isAS ? asIsAeroUnit(u.getUnit()) : u.getUnit().type === 'Aero')) return false;
             const fireSupport = units.filter(u => u.getUnit().role === 'Fire Support');
             const hasDogfighter = units.some(u => u.getUnit().role?.includes('Dogfighter'));
@@ -1705,8 +1665,7 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         minUnits: 6,
         rulesRef: [{ book: Rulebook.CO, page: 68 }, { book: Rulebook.ASCE, page: 122 }],
         requirements: () => 'Minimum 6 units. All must be aerospace units. More than 50% must have an Attack or Dogfighter role.',
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             if (!units.every(u => isAS ? asIsAeroUnit(u.getUnit()) : u.getUnit().type === 'Aero')) return false;
             const count = units.filter(u =>
                 u.getUnit().role?.includes('Attack') || u.getUnit().role?.includes('Dogfighter'));
@@ -1730,14 +1689,11 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         }],
         minUnits: 6,
         rulesRef: [{ book: Rulebook.CO, page: 67 }, { book: Rulebook.ASCE, page: 122 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 6 units. All must be aerospace units. More than 50% must have EW specials (PRB, AECM, ECM, TAG, etc.).';
-            }
-            return 'Minimum 6 units. All must be aerospace units. More than 50% must have ECM, BAP, or TAG equipment.';
+        requirements: () => {
+            const equipment = isAS ? 'EW specials (PRB, AECM, ECM, TAG, etc.)' : 'ECM, BAP, or TAG';
+            return `Minimum 6 units. All must be aerospace units. More than 50% must have ${equipment}.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             if (!units.every(u => isAS ? asIsAeroUnit(u.getUnit()) : u.getUnit().type === 'Aero')) return false;
             if (isAS) {
                 const EW_SPECIALS = ['PRB', 'AECM', 'BH', 'ECM', 'LPRB', 'LECM', 'LTAG', 'TAG', 'WAT'];
@@ -1772,14 +1728,11 @@ export const FORMATION_DEFINITIONS: FormationTypeDefinition[] = [
         }],
         minUnits: 6,
         rulesRef: [{ book: Rulebook.CO, page: 68 }, { book: Rulebook.ASCE, page: 123 }],
-        requirements: (gameSystem) => {
-            if (gameSystem === GameSystem.ALPHA_STRIKE) {
-                return 'Minimum 6 units. All must be aerospace type (AF, CF, SC, DS, SV, or DA). 50% or more must have the Transport role.';
-            }
-            return 'Minimum 6 units. All must be aerospace units. 50% or more must have the Transport role.';
+        requirements: () => {
+            const aerospaceType = isAS ? 'type (AF, CF, SC, DS, SV, or DA)' : 'units';
+            return `Minimum 6 units. All must be aerospace ${aerospaceType}. 50% or more must have the Transport role.`;
         },
-        validator: (units, gameSystem) => {
-            const isAS = gameSystem === GameSystem.ALPHA_STRIKE;
+        validator: (units) => {
             if (isAS) {
                 const allowedTypes: ASUnitTypeCode[] = ['AF', 'CF', 'SC', 'DS', 'SV', 'DA'];
                 if (!units.every(u => allowedTypes.includes(u.getUnit().as?.TP as ASUnitTypeCode))) return false;

--- a/src/app/utils/formation-definitions.ts
+++ b/src/app/utils/formation-definitions.ts
@@ -57,7 +57,7 @@ const AEROSPACE_MODES = new Set(['a', 'p', 'k']);
 
 function isHex(value: number): string {
     const useHex = OptionsService.get()?.options()?.ASUseHex ?? false;
-    return useHex ? `${Math.round(value / 2)}⬢` : `${value}″`;
+    return useHex ? `${Math.floor(value) / 2}⬢` : `${value}″`;
 }
 
 function asGetSize(unit: Unit): number {


### PR DESCRIPTION
Updates inches to hexes depending on setting in options

The following are affected
1. Special Pilot Ability Dropdown inside Warrior Data window
2. Warrior Data window (once SPA has been selected
3. Granted Abilities list in Formation details window
4. Formation Requirements text in Formation details window

two functions were created to allow for dynamic editing of the text based on the selected setting:

1. Formation Requirements
  - helper function isHex('number') that takes the number string in the Formation Requirements text and converts it into hexes
2. function hexDisplay(summaries: string[]) that reads the SPA AS summary text, looks for [['string']] within the array, and converts that text into hex.

Had to create a different method for conversion because in #1 above, '<span class="hex-symbol">⬢</span>' is shown instead of simply ⬢, and in #2, using isHex inside the summary array does not update inches to hex regardless of setting, so a function is used to change the displayed number upon retrieval of the array string.

maybe a more efficient method is possible, but this is more of a proof of concept of the possibility of having the text display be dynamic based on the Inch/Hex setting.

Also, I don't know if there is a boolean that checks the settings for whether inches or hexes are used so I made 'useHex = OptionsService.get()?.options()?.ASUseHex ?? false;' within the functions i made. This can be simplified if such a function exists.