### PR TITLE
Remove ammo consumption check for critical hits

### DIFF
--- a/src/app/utils/mek-critical-hit.util.ts
+++ b/src/app/utils/mek-critical-hit.util.ts
@@ -285,9 +285,6 @@ export function applyMekCriticalRoll(
         })
         : null;
 
-    if (equipment instanceof AmmoEquipment && criticalHitApplied) {
-        slot.consumed = criticalSlotTotalAmmo(unit, slot, equipment);
-    }
     if (delayedExplosion) {
         queueMekComponentExplosion(unit, slot, targetLocation, delayedExplosion, consolidateImmediately);
     }


### PR DESCRIPTION
Removed unused ammo consumption logic for critical hits.